### PR TITLE
Patch for random to use Safe Haskell

### DIFF
--- a/System/Random.hs
+++ b/System/Random.hs
@@ -1,3 +1,7 @@
+#if __GLASGOW_HASKELL__ >= 701
+{-# LANGUAGE Trustworthy #-}
+#endif
+
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  System.Random


### PR DESCRIPTION
Hi Ryan ,

 I'm David Terei, a GHC developer.

 I've worked on a new feature for GHC 7.2 called Safe Haskell. I'd like
 to update random to use it as I'm trying to get all packages included
 with GHC updated.

 Safe Haskell is a new language extension I've been working on with
 David Mazieres and the Simons for GHC 7.2.

http://hackage.haskell.org/trac/ghc/wiki/SafeHaskell

 Basically it provides a language pragmas 'Safe' that restricts the
 module being compiled to only be able to use a subset of the Haskell
 language so that you can trust the type system is sound. (i.e no
 unsafePerformIO). As part of the restriction, the module can only
 import other modules that are considered safe. A module is considered
 Safe if it is compiled with the 'Safe' language pragma or if its
 compiled with the 'Trustworthy' pragma. The trustworthy pragma doesn't
 restrict the features the module can use at all so its appropriate for
 modules that may use unsafe features internally but only export an API
 that can be used in a safe manner. When I speak about safety I'm
 mostly referring to being able to trust the type system and module
 boundaries. Trustworthy compiled modules can therefore import any
 other module, they don't require imports to be safe.

 I've attached a patch that updates random to use Safe Haskell and
 would love it if you could apply.

~ David
