### PR TITLE
prepping for the 1.1 fixup release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# 1.1
+  * breaking change to `randomIValInteger` to improve RNG quality and performance
+    see https://github.com/haskell/random/pull/4 and
+    ghc https://ghc.haskell.org/trac/ghc/ticket/8898
+  * correct documentation about generated range of Int32 sized values of type Int
+    https://github.com/haskell/random/pull/7
+  * fix memory leaks by using strict fields and strict atomicModifyIORef'
+    https://github.com/haskell/random/pull/8
+  * support for base < 4.6 (which doesnt provide strict atomicModifyIORef')
+    and integrating Travis CI support.
+    https://github.com/haskell/random/pull/12
+
+# 1.0.1.1
+bump for overflow bug fixes
+
+# 1.0.1.2
+bump for ticket 8704, build fusion
+
+# 1.0.1.0
+bump for bug fixes,
+
+# 1.0.0.4
+bumped version for float/double range bugfix
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,0 @@
-
-
-1.0.0.4 -- bumped version for float/double range bugfix
-

--- a/random.cabal
+++ b/random.cabal
@@ -1,10 +1,8 @@
 name:		random
-version:	1.0.1.3
+version:	1.1
 
--- 1.0.1.0 -- bump for bug fixes, but no SplittableGen yet
--- 1.0.1.1 -- bump for overflow bug fixes
--- 1.0.1.2 -- bump for ticket 8704, build fusion
--- 1.0.1.3 -- bump for various bug fixes
+
+
 
 license:	BSD3
 license-file:	LICENSE
@@ -16,6 +14,8 @@ description:
 	This package provides a basic random number generation
 	library, including the ability to split random number
 	generators.
+
+
 build-type: Simple
 -- cabal-version 1.8 needed because "the field 'build-depends: random' refers
 -- to a library which is defined within the same package"
@@ -27,7 +27,7 @@ Library
     exposed-modules:
         System.Random
     extensions:	CPP
-    GHC-Options: -O2 
+    GHC-Options: -O2
     build-depends: base >= 3 && < 5, time
 
 source-repository head


### PR DESCRIPTION
1) we still need to merge in  https://github.com/haskell/random/pull/9
2) should we force -O2 in the ghcoptions? (its currently set that way, but is that a good idea/needed here?)
