### PR TITLE
Getting rid of TAB characters

### DIFF
--- a/Benchmark/SimpleRNGBench.hs
+++ b/Benchmark/SimpleRNGBench.hs
@@ -14,7 +14,7 @@ import System.Console.GetOpt
 
 import GHC.Conc
 import Control.Concurrent
-import Control.Monad 
+import Control.Monad
 import Control.Exception
 
 import Data.IORef
@@ -46,10 +46,10 @@ import GHC.IO
 
 -- Readable large integer printing:
 commaint :: (Show a, Integral a) => a -> String
-commaint n = 
+commaint n =
    reverse $ concat $
-   intersperse "," $ 
-   chunksOf 3 $ 
+   intersperse "," $
+   chunksOf 3 $
    reverse (show n)
 
 padleft :: Int -> String -> String
@@ -61,29 +61,29 @@ padright n str | length str >= n = str
 padright n str | otherwise       = str ++ take (n - length str) (repeat ' ')
 
 fmt_num :: (RealFrac a, PrintfArg a) => a -> String
-fmt_num n = if n < 100 
-	    then printf "%.2f" n
-	    else commaint (round n :: Integer)
+fmt_num n = if n < 100
+            then printf "%.2f" n
+            else commaint (round n :: Integer)
 
 
 -- Measure clock frequency, spinning rather than sleeping to try to
 -- stay on the same core.
 measureFreq :: IO Int64
-measureFreq = do 
+measureFreq = do
   let second = 1000 * 1000 * 1000 * 1000 -- picoseconds are annoying
-  t1 <- rdtsc 
+  t1 <- rdtsc
   start <- getCPUTime
-  let loop !n !last = 
-       do t2 <- rdtsc 
-	  when (t2 < last) $
-	       putStrLn$ "COUNTERS WRAPPED "++ show (last,t2) 
-	  cput <- getCPUTime		
-	  if (cput - start < second) 
-	   then loop (n+1) t2
-	   else return (n,t2)
+  let loop !n !last =
+       do t2 <- rdtsc
+          when (t2 < last) $
+               putStrLn$ "COUNTERS WRAPPED "++ show (last,t2)
+          cput <- getCPUTime
+          if (cput - start < second)
+           then loop (n+1) t2
+           else return (n,t2)
   (n,t2) <- loop 0 t1
   putStrLn$ "  Approx getCPUTime calls per second: "++ commaint (n::Int64)
-  when (t2 < t1) $ 
+  when (t2 < t1) $
     putStrLn$ "WARNING: rdtsc not monotonically increasing, first "++show t1++" then "++show t2++" on the same OS thread"
 
   return$ fromIntegral (t2 - t1)
@@ -92,7 +92,7 @@ measureFreq = do
 
 -- Test overheads without actually generating any random numbers:
 data NoopRNG = NoopRNG
-instance RandomGen NoopRNG where 
+instance RandomGen NoopRNG where
   next g     = (0,g)
 #ifdef ENABLE_SPLITTABLEGEN
   genRange _ = (0,0)
@@ -102,7 +102,7 @@ instance SplittableGen NoopRNG where
 
 -- An RNG generating only 0 or 1:
 data BinRNG = BinRNG StdGen
-instance RandomGen BinRNG where 
+instance RandomGen BinRNG where
   next (BinRNG g) = (x `mod` 2, BinRNG g')
     where (x,g') = next g
 #ifdef ENABLE_SPLITTABLEGEN
@@ -117,7 +117,7 @@ instance SplittableGen BinRNG where
 #ifdef TEST_COMPETITORS
 data MWCRNG = MWCRNG (Gen (PrimState IO))
 -- data MWCRNG = MWCRNG GenIO
-instance RandomGen MWCRNG where 
+instance RandomGen MWCRNG where
   -- For testing purposes we hack this to be non-monadic:
 --  next g@(MWCRNG gen) = unsafePerformIO $
   next g@(MWCRNG gen) = unsafeDupablePerformIO $
@@ -136,13 +136,13 @@ type Kern = Int -> Ptr Int -> IO ()
 -- foreign import ccall unsafe "stdlib.hs" rand :: IO Int
 
 {-# INLINE timeit #-}
-timeit :: (Random a, RandomGen g) => 
-	  Int -> Int64 -> String -> g -> (g -> (a,g)) -> IO ()
+timeit :: (Random a, RandomGen g) =>
+          Int -> Int64 -> String -> g -> (g -> (a,g)) -> IO ()
 timeit numthreads freq msg gen nxt =
-  do 
-     counters <- forM [1..numthreads] (const$ newIORef (1::Int64)) 
-     tids <- forM counters $ \counter -> 
-	        forkIO $ infloop counter (nxt gen)   
+  do
+     counters <- forM [1..numthreads] (const$ newIORef (1::Int64))
+     tids <- forM counters $ \counter ->
+                forkIO $ infloop counter (nxt gen)
      threadDelay (1000*1000) -- One second
      mapM_ killThread tids
 
@@ -151,29 +151,29 @@ timeit numthreads freq msg gen nxt =
          cycles_per :: Double = fromIntegral freq / mean
      printResult (round mean :: Int64) msg cycles_per
 
- where 
-   infloop !counter !(!_,!g) = 
+ where
+   infloop !counter !(!_,!g) =
      do incr counter
-	infloop counter (nxt g)
+        infloop counter (nxt g)
 
-   incr !counter = 
+   incr !counter =
      do -- modifyIORef counter (+1) -- Not strict enough!
-	c <- readIORef counter
-	let c' = c+1
-	_ <- evaluate c'
-	writeIORef counter c'     
+        c <- readIORef counter
+        let c' = c+1
+        _ <- evaluate c'
+        writeIORef counter c'
 
 
 -- This function times an IO function on one or more threads.  Rather
 -- than running a fixed number of iterations, it uses a binary search
 -- to find out how many iterations can be completed in a second.
 timeit_foreign :: Int -> Int64 -> String -> (Int -> Ptr Int -> IO ()) -> IO Int64
-timeit_foreign numthreads freq msg ffn = do 
+timeit_foreign numthreads freq msg ffn = do
   ptr     :: ForeignPtr Int <- mallocForeignPtr
 
   let kern = if numthreads == 1
-	     then ffn
-	     else replicate_kernel numthreads ffn 
+             then ffn
+             else replicate_kernel numthreads ffn
       wrapped n = withForeignPtr ptr (kern$ fromIntegral n)
   (n,t) <- binSearch False 1 (1.0, 1.05) wrapped
 
@@ -182,53 +182,53 @@ timeit_foreign numthreads freq msg ffn = do
   printResult total_per_second msg cycles_per
   return total_per_second
 
- where 
+ where
    -- This lifts a C kernel to operate simultaneously on N threads.
    replicate_kernel :: Int -> Kern -> Kern
    replicate_kernel nthreads kern n ptr = do
      ptrs <- forM [1..nthreads]
-	       (const mallocForeignPtr) 
+               (const mallocForeignPtr)
      tmpchan <- newChan
      -- let childwork = ceiling$ fromIntegral n / fromIntegral nthreads
      let childwork = n -- Keep it the same.. interested in per-thread throughput.
      -- Fork/join pattern:
-     _ <- forM ptrs $ \pt -> forkIO $ 
-	      withForeignPtr pt $ \p -> do
-		 kern (fromIntegral childwork) p
-		 result <- peek p
-		 writeChan tmpchan result
+     _ <- forM ptrs $ \pt -> forkIO $
+              withForeignPtr pt $ \p -> do
+                 kern (fromIntegral childwork) p
+                 result <- peek p
+                 writeChan tmpchan result
 
-     results <- forM [1..nthreads] $ \_ -> 
-		  readChan tmpchan
+     results <- forM [1..nthreads] $ \_ ->
+                  readChan tmpchan
      -- Meaningless semantics here... sum the child ptrs and write to the input one:
      poke ptr (foldl1 (+) results)
      return ()
 
 
 printResult ::  Int64 -> String -> Double -> IO ()
-printResult total msg cycles_per = 
+printResult total msg cycles_per =
      putStrLn$ "    "++ padleft 11 (commaint total) ++" randoms generated "++ padright 27 ("["++msg++"]") ++" ~ "
-	       ++ fmt_num cycles_per ++" cycles/int"
+               ++ fmt_num cycles_per ++" cycles/int"
 
 ----------------------------------------------------------------------------------------------------
 -- Main Script
 
-data Flag = NoC | Help 
+data Flag = NoC | Help
   deriving (Show, Eq)
 
 options :: [OptDescr Flag]
-options = 
+options =
    [ Option ['h']  ["help"]  (NoArg Help)  "print program help"
    , Option []     ["noC"]   (NoArg NoC)   "omit C benchmarks, haskell only"
    ]
 
 main :: IO ()
-main = do 
+main = do
    argv <- getArgs
    let (opts,_,other) = getOpt Permute options argv
 
    when (not$ null other) $ do
-       putStrLn$ "ERROR: Unrecognized options: " 
+       putStrLn$ "ERROR: Unrecognized options: "
        mapM_ putStr other
        exitFailure
 
@@ -245,7 +245,7 @@ main = do
    freq <- measureFreq
    putStrLn$ "  Approx clock frequency:  " ++ commaint freq
 
-   let 
+   let
        randInt     = random :: RandomGen g => g -> (Int,g)
        randWord16  = random :: RandomGen g => g -> (Word16,g)
        randFloat   = random :: RandomGen g => g -> (Float,g)
@@ -258,70 +258,70 @@ main = do
 
        gen = mkStdGen 23852358661234
        gamut th = do
-	 putStrLn$ "  First, timing System.Random.next:"
-	 timeit th freq "constant zero gen"      NoopRNG next 
-	 timeit th freq "System.Random stdGen/next" gen  next 
+         putStrLn$ "  First, timing System.Random.next:"
+         timeit th freq "constant zero gen"      NoopRNG next
+         timeit th freq "System.Random stdGen/next" gen  next
 
-	 putStrLn$ "\n  Second, timing System.Random.random at different types:"
-	 timeit th freq "System.Random Ints"     gen   randInt
-	 timeit th freq "System.Random Word16"   gen   randWord16
-	 timeit th freq "System.Random Floats"   gen   randFloat
-	 timeit th freq "System.Random CFloats"  gen   randCFloat
-	 timeit th freq "System.Random Doubles"  gen   randDouble
-	 timeit th freq "System.Random CDoubles" gen   randCDouble
-	 timeit th freq "System.Random Integers" gen   randInteger
-	 timeit th freq "System.Random Bools"    gen   randBool
-	 timeit th freq "System.Random Chars"    gen   randChar
+         putStrLn$ "\n  Second, timing System.Random.random at different types:"
+         timeit th freq "System.Random Ints"     gen   randInt
+         timeit th freq "System.Random Word16"   gen   randWord16
+         timeit th freq "System.Random Floats"   gen   randFloat
+         timeit th freq "System.Random CFloats"  gen   randCFloat
+         timeit th freq "System.Random Doubles"  gen   randDouble
+         timeit th freq "System.Random CDoubles" gen   randCDouble
+         timeit th freq "System.Random Integers" gen   randInteger
+         timeit th freq "System.Random Bools"    gen   randBool
+         timeit th freq "System.Random Chars"    gen   randChar
 
 #ifdef TEST_COMPETITORS
-	 putStrLn$ "\n  Next test other RNG packages on Hackage:"
+         putStrLn$ "\n  Next test other RNG packages on Hackage:"
          let gen_mt = pureMT 39852
              randInt2   = random :: RandomGen g => g -> (Int,g)
-	     randFloat2 = random :: RandomGen g => g -> (Float,g)
-	 timeit th freq "System.Random.Mersenne.Pure64 next"   gen_mt next
-	 timeit th freq "System.Random.Mersenne.Pure64 Ints"   gen_mt randInt2
-	 timeit th freq "System.Random.Mersenne.Pure64 Floats" gen_mt randFloat2
+             randFloat2 = random :: RandomGen g => g -> (Float,g)
+         timeit th freq "System.Random.Mersenne.Pure64 next"   gen_mt next
+         timeit th freq "System.Random.Mersenne.Pure64 Ints"   gen_mt randInt2
+         timeit th freq "System.Random.Mersenne.Pure64 Floats" gen_mt randFloat2
 
          let gen_tf = seedTFGen (0,1,2,3)
              randInt4   = random :: RandomGen g => g -> (Int,g)
-	     randFloat4 = random :: RandomGen g => g -> (Float,g)
+             randFloat4 = random :: RandomGen g => g -> (Float,g)
          timeit th freq "System.Random.TF next" gen_tf next
-	 timeit th freq "System.Random.TF Ints"   gen_tf randInt4
-	 timeit th freq "System.Random.TF Floats" gen_tf randFloat4
+         timeit th freq "System.Random.TF Ints"   gen_tf randInt4
+         timeit th freq "System.Random.TF Floats" gen_tf randFloat4
 
          withSystemRandom $ \ gen_mwc -> do
-	    let randInt3   = random :: RandomGen g => g -> (Int,g)
-		randFloat3 = random :: RandomGen g => g -> (Float,g)
+            let randInt3   = random :: RandomGen g => g -> (Int,g)
+                randFloat3 = random :: RandomGen g => g -> (Float,g)
 
-	    timeit th freq "System.Random.MWC next"   (MWCRNG gen_mwc) next
-	    timeit th freq "System.Random.MWC Ints"   (MWCRNG gen_mwc) randInt3
-	    timeit th freq "System.Random.MWC Floats" (MWCRNG gen_mwc) randFloat3
+            timeit th freq "System.Random.MWC next"   (MWCRNG gen_mwc) next
+            timeit th freq "System.Random.MWC Ints"   (MWCRNG gen_mwc) randInt3
+            timeit th freq "System.Random.MWC Floats" (MWCRNG gen_mwc) randFloat3
 
 #endif
 
-	 putStrLn$ "\n  Next timing range-restricted System.Random.randomR:"
-	 timeit th freq "System.Random Ints"     gen   (randomR (-100, 100::Int))
-	 timeit th freq "System.Random Word16s"  gen   (randomR (-100, 100::Word16))
-	 timeit th freq "System.Random Floats"   gen   (randomR (-100, 100::Float))
-	 timeit th freq "System.Random CFloats"  gen   (randomR (-100, 100::CFloat))
-	 timeit th freq "System.Random Doubles"  gen   (randomR (-100, 100::Double))
-	 timeit th freq "System.Random CDoubles" gen   (randomR (-100, 100::CDouble))
-	 timeit th freq "System.Random Integers" gen   (randomR (-100, 100::Integer))
-	 timeit th freq "System.Random Bools"    gen   (randomR (False, True::Bool))
-	 timeit th freq "System.Random Chars"    gen   (randomR ('a', 'z'))
-	 timeit th freq "System.Random BIG Integers" gen (randomR (0, (2::Integer) ^ (5000::Int)))
+         putStrLn$ "\n  Next timing range-restricted System.Random.randomR:"
+         timeit th freq "System.Random Ints"     gen   (randomR (-100, 100::Int))
+         timeit th freq "System.Random Word16s"  gen   (randomR (-100, 100::Word16))
+         timeit th freq "System.Random Floats"   gen   (randomR (-100, 100::Float))
+         timeit th freq "System.Random CFloats"  gen   (randomR (-100, 100::CFloat))
+         timeit th freq "System.Random Doubles"  gen   (randomR (-100, 100::Double))
+         timeit th freq "System.Random CDoubles" gen   (randomR (-100, 100::CDouble))
+         timeit th freq "System.Random Integers" gen   (randomR (-100, 100::Integer))
+         timeit th freq "System.Random Bools"    gen   (randomR (False, True::Bool))
+         timeit th freq "System.Random Chars"    gen   (randomR ('a', 'z'))
+         timeit th freq "System.Random BIG Integers" gen (randomR (0, (2::Integer) ^ (5000::Int)))
 
-  --       when (not$ NoC `elem` opts) $ do
-  --	  putStrLn$ "  Comparison to C's rand():"
-  --	  timeit_foreign th freq "ptr store in C loop"   store_loop
-  --	  timeit_foreign th freq "rand/store in C loop"  blast_rands
-  --	  timeit_foreign th freq "rand in Haskell loop" (\n ptr -> forM_ [1..n]$ \_ -> rand )
-  --	  timeit_foreign th freq "rand/store in Haskell loop"  (\n ptr -> forM_ [1..n]$ \_ -> do n <- rand; poke ptr n )
-  --	  return ()
+--       when (not$ NoC `elem` opts) $ do
+--           putStrLn$ "  Comparison to C's rand():"
+--           timeit_foreign th freq "ptr store in C loop"   store_loop
+--           timeit_foreign th freq "rand/store in C loop"  blast_rands
+--           timeit_foreign th freq "rand in Haskell loop" (\n ptr -> forM_ [1..n]$ \_ -> rand )
+--           timeit_foreign th freq "rand/store in Haskell loop"  (\n ptr -> forM_ [1..n]$ \_ -> do n <- rand; poke ptr n )
+--           return ()
 
    -- Test with 1 thread and numCapabilities threads:
    gamut 1
-   when (numCapabilities > 1) $ do 
+   when (numCapabilities > 1) $ do
        putStrLn$ "\nNow "++ show numCapabilities ++" threads, reporting mean randoms-per-second-per-thread:"
        gamut numCapabilities
        return ()

--- a/random.cabal
+++ b/random.cabal
@@ -1,19 +1,19 @@
-name:		random
-version:	1.1
+name:           random
+version:        1.1
 
 
 
 
-license:	BSD3
-license-file:	LICENSE
-maintainer:	core-libraries-committee@haskell.org
-bug-reports:	https://github.com/haskell/random/issues
-synopsis:	random number library
+license:        BSD3
+license-file:   LICENSE
+maintainer:     core-libraries-committee@haskell.org
+bug-reports:    https://github.com/haskell/random/issues
+synopsis:       random number library
 category:       System
 description:
-	This package provides a basic random number generation
-	library, including the ability to split random number
-	generators.
+        This package provides a basic random number generation
+        library, including the ability to split random number
+        generators.
 
 extra-source-files:
   .travis.yml
@@ -34,7 +34,7 @@ cabal-version: >= 1.8
 Library
     exposed-modules:
         System.Random
-    extensions:	CPP
+    extensions: CPP
     GHC-Options: -O2
     build-depends: base >= 3 && < 5, time
 

--- a/tests/rangeTest.hs
+++ b/tests/rangeTest.hs
@@ -7,18 +7,18 @@ import Data.Bits
 import Foreign.C.Types
 
 -- Take many measurements and record the max/min/average random values.
-approxBounds :: (RandomGen g, Random a, Ord a, Num a) => 
-		(g -> (a,g)) -> Int -> a -> (a,a) -> g -> ((a,a,a),g)
+approxBounds :: (RandomGen g, Random a, Ord a, Num a) =>
+                (g -> (a,g)) -> Int -> a -> (a,a) -> g -> ((a,a,a),g)
 -- Here we do a little hack to essentiall pass in the type in the last argument:
-approxBounds nxt iters unused (explo,exphi) initrng = 
-   if False 
+approxBounds nxt iters unused (explo,exphi) initrng =
+   if False
    then ((unused,unused,unused),undefined)
 --   else loop initrng iters 100 (-100) 0 -- Oops, can't use minBound/maxBound here.
    else loop initrng iters exphi explo 0 -- Oops, can't use minBound/maxBound here.
- where 
+ where
   loop rng 0 mn mx sum = ((mn,mx,sum),rng)
-  loop rng  n mn mx sum = 
-    case nxt rng of 
+  loop rng  n mn mx sum =
+    case nxt rng of
       (x, rng') -> loop rng' (n-1) (min x mn) (max x mx) (x+sum)
 
 
@@ -28,12 +28,12 @@ approxBounds nxt iters unused (explo,exphi) initrng =
 -- The with (2) is that we do enough trials to ensure that we can at
 -- least hit the 90% mark.
 checkBounds:: (Real a, Show a, Ord a) =>
-	      String -> (Bool, a, a) -> ((a,a) -> StdGen -> ((a, a, t), StdGen)) -> IO ()
-checkBounds msg (exclusive,lo,hi) fun = 
- -- (lo,hi) is [inclusive,exclusive) 
- do putStr$ msg 
---	    ++ ", expected range " ++ show (lo,hi) 
-	    ++ ":  "
+              String -> (Bool, a, a) -> ((a,a) -> StdGen -> ((a, a, t), StdGen)) -> IO ()
+checkBounds msg (exclusive,lo,hi) fun =
+ -- (lo,hi) is [inclusive,exclusive)
+ do putStr$ msg
+--          ++ ", expected range " ++ show (lo,hi)
+            ++ ":  "
     (mn,mx,sum) <- getStdRandom (fun (lo,hi))
     when (mn <  lo)$ error$ "broke lower bound: " ++ show mn
     when (mx > hi) $ error$ "broke upper bound: " ++ show mx
@@ -43,7 +43,7 @@ checkBounds msg (exclusive,lo,hi) fun =
 
     when (toRational (hi - mx) > epsilon)$ error$ "didn't get close enough to upper bound: "++ show mx
     when (toRational (mn - lo) > epsilon)$ error$ "didn't get close enough to lower bound: "++ show mn
-    putStrLn "Passed" 
+    putStrLn "Passed"
 
 boundedRange :: (Num a, Bounded a) => (Bool, a, a)
 boundedRange  = ( False, minBound, maxBound )
@@ -53,8 +53,8 @@ trials = 5000
 -- Keep in mind here that on some architectures (e.g. ARM) CChar, CWchar, and CSigAtomic
 -- are unsigned
 
-main = 
- do 
+main =
+ do
     checkBounds "Int"     boundedRange   (approxBounds random trials (undefined::Int))
     checkBounds "Integer" (False, fromIntegral (minBound::Int), fromIntegral (maxBound::Int))
                                          (approxBounds random trials (undefined::Integer))


### PR DESCRIPTION
This causes a lot of warnings while compiling, since -fwarn-tabs is
enabled by default.