### PR TITLE
Fix for GHC testsuite

### DIFF
--- a/tests/all.T
+++ b/tests/all.T
@@ -1,3 +1,4 @@
+setTestOpts(reqlib('random'))
 
 test('rangeTest',
      normal,


### PR DESCRIPTION
For better or worse, `random` is part of the GHC testsuite. Please merge this one line change to `tests/all.T`.

It fixes the following problem that SPJ had, when he wrote to the ghc-devs mailinglist:
```
I’m getting this collection of failing tests, all of a sudden (below).  What’s up?  I’m pretty sure it’s not my modifications.

The failures are

 

=====> random1283(normal) 1 of 1 [0, 0, 0]

cd . &&  "/5playpen/simonpj/HEAD-4/inplace/test   spaces/ghc-stage2" -o random1283 random1283.hs -fforce-recomp -dcore-lint -dcmm-lint -dno-debug-output -no-user-package-db -rtsopts -fno-warn-tabs -fno-warn-missed-specialisations -fno-ghci-history   -package containers > random1283.comp.stderr 2>&1

Compile failed (status 256) errors were:

[1 of 1] Compiling Main             ( random1283.hs, random1283.o )
...
```