### PR TITLE
Add NOINLINE pragma to theStdGen

### DIFF
--- a/System/Random.hs
+++ b/System/Random.hs
@@ -566,6 +566,9 @@ theStdGen :: IORef StdGen
 theStdGen  = unsafePerformIO $ do
    rng <- mkStdRNG 0
    newIORef rng
+-- We never want this to inline this, because we could end up with
+-- multiple generators, each starting from the initial value.
+{-# NOINLINE theStdGen #-}
 
 -- |Applies 'split' to the current global random generator,
 -- updates it with one of the results, and returns the other.


### PR DESCRIPTION
We never want to inline `theStdGen`, as that could lead to
multiple generators, each starting from the initial value.

Fixes #46