### PR TITLE
facelift README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,11 @@ This library provides a basic interface for (splittable) random number generator
 
 The API documentation can be found here:
 
-   http://hackage.haskell.org/package/random/docs/System-Random.html
+> http://hackage.haskell.org/package/random/docs/System-Random.html
 
 A module supplying this interface is required for Haskell 98 (but not Haskell
-2010). An older [version]
-(http://www.haskell.org/ghc/docs/latest/html/libraries/haskell98/Random.html)
+2010). An older [version](http://www.haskell.org/ghc/docs/latest/html/libraries/haskell98/Random.html)
 of this library is included with GHC in the haskell98 package. This newer
-version, with compatible api, is included in the [Haskell Platform]
-(http://www.haskell.org/platform/contents.html).
+version, with compatible api, is included in the [Haskell Platform](http://www.haskell.org/platform/contents.html).
 
-Please report bugs in the Github [issue tracker] (https://github.com/haskell/random/issues) (no longer in the GHC trac).
+Please report bugs in the Github [issue tracker](https://github.com/haskell/random/issues).

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ The API documentation can be found here:
 > http://hackage.haskell.org/package/random/docs/System-Random.html
 
 A module supplying this interface is required for Haskell 98 (but not Haskell
-2010). An older [version](http://www.haskell.org/ghc/docs/latest/html/libraries/haskell98/Random.html)
-of this library is included with GHC in the haskell98 package. This newer
+2010). An older [version](https://downloads.haskell.org/~ghc/7.6.3/docs/html/libraries/haskell98/Random.html)
+of this library is included with GHC in the `haskell98` package. This newer
 version, with compatible api, is included in the [Haskell Platform](http://www.haskell.org/platform/contents.html).
 
 Please report bugs in the Github [issue tracker](https://github.com/haskell/random/issues).


### PR DESCRIPTION
Mostly, remove extraneous spaces between [] and () in MD-style hyperlinks.