### PR TITLE
Introduce Gauge benchmarks

### DIFF
--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -3,71 +3,58 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module Main (main) where
 
-import Control.Monad
 import Data.Int
 import Data.Proxy
 import Data.Typeable
 import Data.Word
 import Foreign.C.Types
 import Gauge.Main
-import Numeric.Natural (Natural)
-import System.Random.SplitMix as SM
 
-import System.Random.Stateful
+import System.Random
 
 main :: IO ()
 main = do
   let !sz = 100000
-      genLengths =
-        -- create 5000 small lengths that are needed for ShortByteString generation
-        runStateGen (mkStdGen 2020) $ \g -> replicateM 5000 (uniformRM (16 + 1, 16 + 7) g)
   defaultMain
-    [ bgroup "baseline"
-      [ let !smGen = SM.mkSMGen 1337 in bench "nextWord32" $ nf (genMany SM.nextWord32 smGen) sz
-      , let !smGen = SM.mkSMGen 1337 in bench "nextWord64" $ nf (genMany SM.nextWord64 smGen) sz
-      , let !smGen = SM.mkSMGen 1337 in bench "nextInt" $ nf (genMany SM.nextInt smGen) sz
-      , let !smGen = SM.mkSMGen 1337 in bench "split" $ nf (genMany SM.splitSMGen smGen) sz
-      ]
-    , bgroup "pure"
+    [ bgroup "pure"
       [ bgroup "random"
         [ pureRandomBench (Proxy :: Proxy Float) sz
         , pureRandomBench (Proxy :: Proxy Double) sz
         , pureRandomBench (Proxy :: Proxy Integer) sz
+        , pureRandomBench (Proxy :: Proxy Word8) sz
+        , pureRandomBench (Proxy :: Proxy Word16) sz
+        , pureRandomBench (Proxy :: Proxy Word32) sz
+        , pureRandomBench (Proxy :: Proxy Word64) sz
+        , pureRandomBench (Proxy :: Proxy Word) sz
+        , pureRandomBench (Proxy :: Proxy Int8) sz
+        , pureRandomBench (Proxy :: Proxy Int16) sz
+        , pureRandomBench (Proxy :: Proxy Int32) sz
+        , pureRandomBench (Proxy :: Proxy Int64) sz
+        , pureRandomBench (Proxy :: Proxy Int) sz
+        , pureRandomBench (Proxy :: Proxy Char) sz
+        , pureRandomBench (Proxy :: Proxy Bool) sz
+        -- , pureRandomBench (Proxy :: Proxy CBool) sz
+        , pureRandomBench (Proxy :: Proxy CChar) sz
+        , pureRandomBench (Proxy :: Proxy CSChar) sz
+        , pureRandomBench (Proxy :: Proxy CUChar) sz
+        , pureRandomBench (Proxy :: Proxy CShort) sz
+        , pureRandomBench (Proxy :: Proxy CUShort) sz
+        , pureRandomBench (Proxy :: Proxy CInt) sz
+        , pureRandomBench (Proxy :: Proxy CUInt) sz
+        , pureRandomBench (Proxy :: Proxy CLong) sz
+        , pureRandomBench (Proxy :: Proxy CULong) sz
+        , pureRandomBench (Proxy :: Proxy CPtrdiff) sz
+        , pureRandomBench (Proxy :: Proxy CSize) sz
+        , pureRandomBench (Proxy :: Proxy CWchar) sz
+        , pureRandomBench (Proxy :: Proxy CSigAtomic) sz
+        , pureRandomBench (Proxy :: Proxy CLLong) sz
+        , pureRandomBench (Proxy :: Proxy CULLong) sz
+        , pureRandomBench (Proxy :: Proxy CIntPtr) sz
+        , pureRandomBench (Proxy :: Proxy CUIntPtr) sz
+        , pureRandomBench (Proxy :: Proxy CIntMax) sz
+        , pureRandomBench (Proxy :: Proxy CUIntMax) sz
         ]
-      , bgroup "uniform"
-        [ pureUniformBench (Proxy :: Proxy Word8) sz
-        , pureUniformBench (Proxy :: Proxy Word16) sz
-        , pureUniformBench (Proxy :: Proxy Word32) sz
-        , pureUniformBench (Proxy :: Proxy Word64) sz
-        , pureUniformBench (Proxy :: Proxy Word) sz
-        , pureUniformBench (Proxy :: Proxy Int8) sz
-        , pureUniformBench (Proxy :: Proxy Int16) sz
-        , pureUniformBench (Proxy :: Proxy Int32) sz
-        , pureUniformBench (Proxy :: Proxy Int64) sz
-        , pureUniformBench (Proxy :: Proxy Int) sz
-        , pureUniformBench (Proxy :: Proxy Char) sz
-        , pureUniformBench (Proxy :: Proxy Bool) sz
-        , pureUniformBench (Proxy :: Proxy CChar) sz
-        , pureUniformBench (Proxy :: Proxy CSChar) sz
-        , pureUniformBench (Proxy :: Proxy CUChar) sz
-        , pureUniformBench (Proxy :: Proxy CShort) sz
-        , pureUniformBench (Proxy :: Proxy CUShort) sz
-        , pureUniformBench (Proxy :: Proxy CInt) sz
-        , pureUniformBench (Proxy :: Proxy CUInt) sz
-        , pureUniformBench (Proxy :: Proxy CLong) sz
-        , pureUniformBench (Proxy :: Proxy CULong) sz
-        , pureUniformBench (Proxy :: Proxy CPtrdiff) sz
-        , pureUniformBench (Proxy :: Proxy CSize) sz
-        , pureUniformBench (Proxy :: Proxy CWchar) sz
-        , pureUniformBench (Proxy :: Proxy CSigAtomic) sz
-        , pureUniformBench (Proxy :: Proxy CLLong) sz
-        , pureUniformBench (Proxy :: Proxy CULLong) sz
-        , pureUniformBench (Proxy :: Proxy CIntPtr) sz
-        , pureUniformBench (Proxy :: Proxy CUIntPtr) sz
-        , pureUniformBench (Proxy :: Proxy CIntMax) sz
-        , pureUniformBench (Proxy :: Proxy CUIntMax) sz
-        ]
-      , bgroup "uniformR"
+      , bgroup "randomR"
         [ bgroup "full"
           [ pureUniformRFullBench (Proxy :: Proxy Word8) sz
           , pureUniformRFullBench (Proxy :: Proxy Word16) sz
@@ -81,6 +68,7 @@ main = do
           , pureUniformRFullBench (Proxy :: Proxy Int) sz
           , pureUniformRFullBench (Proxy :: Proxy Char) sz
           , pureUniformRFullBench (Proxy :: Proxy Bool) sz
+          -- , pureUniformRFullBench (Proxy :: Proxy CBool) sz
           , pureUniformRFullBench (Proxy :: Proxy CChar) sz
           , pureUniformRFullBench (Proxy :: Proxy CSChar) sz
           , pureUniformRFullBench (Proxy :: Proxy CUChar) sz
@@ -113,6 +101,7 @@ main = do
           , pureUniformRExcludeMaxBench (Proxy :: Proxy Int64) sz
           , pureUniformRExcludeMaxBench (Proxy :: Proxy Int) sz
           , pureUniformRExcludeMaxBench (Proxy :: Proxy Char) sz
+          -- , pureUniformRExcludeMaxBench (Proxy :: Proxy CBool) sz
           , pureUniformRExcludeMaxBench (Proxy :: Proxy Bool) sz
           , pureUniformRExcludeMaxBench (Proxy :: Proxy CChar) sz
           , pureUniformRExcludeMaxBench (Proxy :: Proxy CSChar) sz
@@ -146,6 +135,7 @@ main = do
           , pureUniformRIncludeHalfBench (Proxy :: Proxy Int64) sz
           , pureUniformRIncludeHalfBench (Proxy :: Proxy Int) sz
           , pureUniformRIncludeHalfEnumBench (Proxy :: Proxy Char) sz
+          -- , pureUniformRIncludeHalfEnumBench (Proxy :: Proxy CBool) sz
           , pureUniformRIncludeHalfEnumBench (Proxy :: Proxy Bool) sz
           , pureUniformRIncludeHalfBench (Proxy :: Proxy CChar) sz
           , pureUniformRIncludeHalfBench (Proxy :: Proxy CSChar) sz
@@ -173,14 +163,9 @@ main = do
           , let !i = (10 :: Integer) ^ (100 :: Integer)
                 !range = (-i - 1, i + 1)
             in pureUniformRBench (Proxy :: Proxy Integer) range sz
-          , let !n = (10 :: Natural) ^ (100 :: Natural)
-                !range = (1, n - 1)
-            in pureUniformRBench (Proxy :: Proxy Natural) range sz
-          ]
-        , bgroup "ShortByteString"
-          [ env (pure genLengths) $ \ ~(ns, gen) ->
-              bench "genShortByteString" $
-              nfIO $ runStateGenT_ gen $ \g -> mapM (`uniformShortByteString` g) ns
+          -- , let !n = (10 :: Natural) ^ (100 :: Natural)
+          --       !range = (1, n - 1)
+          --   in pureUniformRBench (Proxy :: Proxy Natural) range sz
           ]
         ]
       ]
@@ -191,13 +176,8 @@ pureRandomBench px =
   let !stdGen = mkStdGen 1337
    in pureBench px (genMany (random :: StdGen -> (a, StdGen)) stdGen)
 
-pureUniformBench :: forall a. (Typeable a, Uniform a) => Proxy a -> Int -> Benchmark
-pureUniformBench px =
-  let !stdGen = mkStdGen 1337
-   in pureBench px (genMany (uniform :: StdGen -> (a, StdGen)) stdGen)
-
 pureUniformRFullBench ::
-     forall a. (Typeable a, UniformRange a, Bounded a)
+     forall a. (Typeable a, Random a, Bounded a)
   => Proxy a
   -> Int
   -> Benchmark
@@ -206,7 +186,7 @@ pureUniformRFullBench px =
    in pureUniformRBench px range
 
 pureUniformRExcludeMaxBench ::
-     forall a. (Typeable a, UniformRange a, Bounded a, Enum a)
+     forall a. (Typeable a, Random a, Bounded a, Enum a)
   => Proxy a
   -> Int
   -> Benchmark
@@ -215,7 +195,7 @@ pureUniformRExcludeMaxBench px =
    in pureUniformRBench px range
 
 pureUniformRIncludeHalfBench ::
-     forall a. (Typeable a, UniformRange a, Bounded a, Integral a)
+     forall a. (Typeable a, Random a, Bounded a, Integral a)
   => Proxy a
   -> Int
   -> Benchmark
@@ -224,7 +204,7 @@ pureUniformRIncludeHalfBench px =
   in pureUniformRBench px range
 
 pureUniformRIncludeHalfEnumBench ::
-     forall a. (Typeable a, UniformRange a, Bounded a, Enum a)
+     forall a. (Typeable a, Random a, Bounded a, Enum a)
   => Proxy a
   -> Int
   -> Benchmark
@@ -233,14 +213,14 @@ pureUniformRIncludeHalfEnumBench px =
   in pureUniformRBench px range
 
 pureUniformRBench ::
-     forall a. (Typeable a, UniformRange a)
+     forall a. (Typeable a, Random a)
   => Proxy a
   -> (a, a)
   -> Int
   -> Benchmark
 pureUniformRBench px range@(!_, !_) =
   let !stdGen = mkStdGen 1337
-  in pureBench px (genMany (uniformR range) stdGen)
+  in pureBench px (genMany (randomR range) stdGen)
 
 pureBench :: forall a. (Typeable a) => Proxy a -> (Int -> ()) -> Int -> Benchmark
 pureBench px f sz = bench (showsTypeRep (typeRep px) "") $ nf f sz

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -1,0 +1,255 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Main (main) where
+
+import Control.Monad
+import Data.Int
+import Data.Proxy
+import Data.Typeable
+import Data.Word
+import Foreign.C.Types
+import Gauge.Main
+import Numeric.Natural (Natural)
+import System.Random.SplitMix as SM
+
+import System.Random.Stateful
+
+main :: IO ()
+main = do
+  let !sz = 100000
+      genLengths =
+        -- create 5000 small lengths that are needed for ShortByteString generation
+        runStateGen (mkStdGen 2020) $ \g -> replicateM 5000 (uniformRM (16 + 1, 16 + 7) g)
+  defaultMain
+    [ bgroup "baseline"
+      [ let !smGen = SM.mkSMGen 1337 in bench "nextWord32" $ nf (genMany SM.nextWord32 smGen) sz
+      , let !smGen = SM.mkSMGen 1337 in bench "nextWord64" $ nf (genMany SM.nextWord64 smGen) sz
+      , let !smGen = SM.mkSMGen 1337 in bench "nextInt" $ nf (genMany SM.nextInt smGen) sz
+      , let !smGen = SM.mkSMGen 1337 in bench "split" $ nf (genMany SM.splitSMGen smGen) sz
+      ]
+    , bgroup "pure"
+      [ bgroup "random"
+        [ pureRandomBench (Proxy :: Proxy Float) sz
+        , pureRandomBench (Proxy :: Proxy Double) sz
+        , pureRandomBench (Proxy :: Proxy Integer) sz
+        ]
+      , bgroup "uniform"
+        [ pureUniformBench (Proxy :: Proxy Word8) sz
+        , pureUniformBench (Proxy :: Proxy Word16) sz
+        , pureUniformBench (Proxy :: Proxy Word32) sz
+        , pureUniformBench (Proxy :: Proxy Word64) sz
+        , pureUniformBench (Proxy :: Proxy Word) sz
+        , pureUniformBench (Proxy :: Proxy Int8) sz
+        , pureUniformBench (Proxy :: Proxy Int16) sz
+        , pureUniformBench (Proxy :: Proxy Int32) sz
+        , pureUniformBench (Proxy :: Proxy Int64) sz
+        , pureUniformBench (Proxy :: Proxy Int) sz
+        , pureUniformBench (Proxy :: Proxy Char) sz
+        , pureUniformBench (Proxy :: Proxy Bool) sz
+        , pureUniformBench (Proxy :: Proxy CChar) sz
+        , pureUniformBench (Proxy :: Proxy CSChar) sz
+        , pureUniformBench (Proxy :: Proxy CUChar) sz
+        , pureUniformBench (Proxy :: Proxy CShort) sz
+        , pureUniformBench (Proxy :: Proxy CUShort) sz
+        , pureUniformBench (Proxy :: Proxy CInt) sz
+        , pureUniformBench (Proxy :: Proxy CUInt) sz
+        , pureUniformBench (Proxy :: Proxy CLong) sz
+        , pureUniformBench (Proxy :: Proxy CULong) sz
+        , pureUniformBench (Proxy :: Proxy CPtrdiff) sz
+        , pureUniformBench (Proxy :: Proxy CSize) sz
+        , pureUniformBench (Proxy :: Proxy CWchar) sz
+        , pureUniformBench (Proxy :: Proxy CSigAtomic) sz
+        , pureUniformBench (Proxy :: Proxy CLLong) sz
+        , pureUniformBench (Proxy :: Proxy CULLong) sz
+        , pureUniformBench (Proxy :: Proxy CIntPtr) sz
+        , pureUniformBench (Proxy :: Proxy CUIntPtr) sz
+        , pureUniformBench (Proxy :: Proxy CIntMax) sz
+        , pureUniformBench (Proxy :: Proxy CUIntMax) sz
+        ]
+      , bgroup "uniformR"
+        [ bgroup "full"
+          [ pureUniformRFullBench (Proxy :: Proxy Word8) sz
+          , pureUniformRFullBench (Proxy :: Proxy Word16) sz
+          , pureUniformRFullBench (Proxy :: Proxy Word32) sz
+          , pureUniformRFullBench (Proxy :: Proxy Word64) sz
+          , pureUniformRFullBench (Proxy :: Proxy Word) sz
+          , pureUniformRFullBench (Proxy :: Proxy Int8) sz
+          , pureUniformRFullBench (Proxy :: Proxy Int16) sz
+          , pureUniformRFullBench (Proxy :: Proxy Int32) sz
+          , pureUniformRFullBench (Proxy :: Proxy Int64) sz
+          , pureUniformRFullBench (Proxy :: Proxy Int) sz
+          , pureUniformRFullBench (Proxy :: Proxy Char) sz
+          , pureUniformRFullBench (Proxy :: Proxy Bool) sz
+          , pureUniformRFullBench (Proxy :: Proxy CChar) sz
+          , pureUniformRFullBench (Proxy :: Proxy CSChar) sz
+          , pureUniformRFullBench (Proxy :: Proxy CUChar) sz
+          , pureUniformRFullBench (Proxy :: Proxy CShort) sz
+          , pureUniformRFullBench (Proxy :: Proxy CUShort) sz
+          , pureUniformRFullBench (Proxy :: Proxy CInt) sz
+          , pureUniformRFullBench (Proxy :: Proxy CUInt) sz
+          , pureUniformRFullBench (Proxy :: Proxy CLong) sz
+          , pureUniformRFullBench (Proxy :: Proxy CULong) sz
+          , pureUniformRFullBench (Proxy :: Proxy CPtrdiff) sz
+          , pureUniformRFullBench (Proxy :: Proxy CSize) sz
+          , pureUniformRFullBench (Proxy :: Proxy CWchar) sz
+          , pureUniformRFullBench (Proxy :: Proxy CSigAtomic) sz
+          , pureUniformRFullBench (Proxy :: Proxy CLLong) sz
+          , pureUniformRFullBench (Proxy :: Proxy CULLong) sz
+          , pureUniformRFullBench (Proxy :: Proxy CIntPtr) sz
+          , pureUniformRFullBench (Proxy :: Proxy CUIntPtr) sz
+          , pureUniformRFullBench (Proxy :: Proxy CIntMax) sz
+          , pureUniformRFullBench (Proxy :: Proxy CUIntMax) sz
+          ]
+        , bgroup "excludeMax"
+          [ pureUniformRExcludeMaxBench (Proxy :: Proxy Word8) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy Word16) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy Word32) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy Word64) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy Word) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy Int8) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy Int16) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy Int32) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy Int64) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy Int) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy Char) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy Bool) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CChar) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CSChar) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CUChar) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CShort) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CUShort) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CInt) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CUInt) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CLong) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CULong) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CPtrdiff) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CSize) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CWchar) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CSigAtomic) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CLLong) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CULLong) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CIntPtr) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CUIntPtr) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CIntMax) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CUIntMax) sz
+          ]
+        , bgroup "includeHalf"
+          [ pureUniformRIncludeHalfBench (Proxy :: Proxy Word8) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy Word16) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy Word32) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy Word64) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy Word) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy Int8) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy Int16) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy Int32) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy Int64) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy Int) sz
+          , pureUniformRIncludeHalfEnumBench (Proxy :: Proxy Char) sz
+          , pureUniformRIncludeHalfEnumBench (Proxy :: Proxy Bool) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CChar) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CSChar) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CUChar) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CShort) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CUShort) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CInt) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CUInt) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CLong) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CULong) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CPtrdiff) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CSize) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CWchar) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CSigAtomic) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CLLong) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CULLong) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CIntPtr) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CUIntPtr) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CIntMax) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CUIntMax) sz
+          ]
+        , bgroup "unbounded"
+          [ pureUniformRBench (Proxy :: Proxy Float) (1.23e-4, 5.67e8) sz
+          , pureUniformRBench (Proxy :: Proxy Double) (1.23e-4, 5.67e8) sz
+          , let !i = (10 :: Integer) ^ (100 :: Integer)
+                !range = (-i - 1, i + 1)
+            in pureUniformRBench (Proxy :: Proxy Integer) range sz
+          , let !n = (10 :: Natural) ^ (100 :: Natural)
+                !range = (1, n - 1)
+            in pureUniformRBench (Proxy :: Proxy Natural) range sz
+          ]
+        , bgroup "ShortByteString"
+          [ env (pure genLengths) $ \ ~(ns, gen) ->
+              bench "genShortByteString" $
+              nfIO $ runStateGenT_ gen $ \g -> mapM (`uniformShortByteString` g) ns
+          ]
+        ]
+      ]
+    ]
+
+pureRandomBench :: forall a. (Typeable a, Random a) => Proxy a -> Int -> Benchmark
+pureRandomBench px =
+  let !stdGen = mkStdGen 1337
+   in pureBench px (genMany (random :: StdGen -> (a, StdGen)) stdGen)
+
+pureUniformBench :: forall a. (Typeable a, Uniform a) => Proxy a -> Int -> Benchmark
+pureUniformBench px =
+  let !stdGen = mkStdGen 1337
+   in pureBench px (genMany (uniform :: StdGen -> (a, StdGen)) stdGen)
+
+pureUniformRFullBench ::
+     forall a. (Typeable a, UniformRange a, Bounded a)
+  => Proxy a
+  -> Int
+  -> Benchmark
+pureUniformRFullBench px =
+  let range = (minBound :: a, maxBound :: a)
+   in pureUniformRBench px range
+
+pureUniformRExcludeMaxBench ::
+     forall a. (Typeable a, UniformRange a, Bounded a, Enum a)
+  => Proxy a
+  -> Int
+  -> Benchmark
+pureUniformRExcludeMaxBench px =
+  let range = (minBound :: a, pred (maxBound :: a))
+   in pureUniformRBench px range
+
+pureUniformRIncludeHalfBench ::
+     forall a. (Typeable a, UniformRange a, Bounded a, Integral a)
+  => Proxy a
+  -> Int
+  -> Benchmark
+pureUniformRIncludeHalfBench px =
+  let range = ((minBound :: a) + 1, ((maxBound :: a) `div` 2) + 1)
+  in pureUniformRBench px range
+
+pureUniformRIncludeHalfEnumBench ::
+     forall a. (Typeable a, UniformRange a, Bounded a, Enum a)
+  => Proxy a
+  -> Int
+  -> Benchmark
+pureUniformRIncludeHalfEnumBench px =
+  let range = (succ (minBound :: a), toEnum ((fromEnum (maxBound :: a) `div` 2) + 1))
+  in pureUniformRBench px range
+
+pureUniformRBench ::
+     forall a. (Typeable a, UniformRange a)
+  => Proxy a
+  -> (a, a)
+  -> Int
+  -> Benchmark
+pureUniformRBench px range@(!_, !_) =
+  let !stdGen = mkStdGen 1337
+  in pureBench px (genMany (uniformR range) stdGen)
+
+pureBench :: forall a. (Typeable a) => Proxy a -> (Int -> ()) -> Int -> Benchmark
+pureBench px f sz = bench (showsTypeRep (typeRep px) "") $ nf f sz
+
+genMany :: (g -> (a, g)) -> g -> Int -> ()
+genMany f g0 n = go g0 0
+  where
+    go g i
+      | i < n =
+        case f g of
+          (x, g') -> x `seq` go g' (i + 1)
+      | otherwise = g `seq` ()

--- a/random.cabal
+++ b/random.cabal
@@ -68,3 +68,13 @@ Test-Suite TestRandomIOs
     hs-source-dirs: tests
     build-depends:  base >= 3 && < 5, random
     ghc-options:    -rtsopts -O2
+
+benchmark bench
+    type:           exitcode-stdio-1.0
+    main-is:        Main.hs
+    hs-source-dirs: bench
+    ghc-options:    -Wall -O2
+    build-depends:
+        base >=4.10 && <5,
+        gauge >=0.2.3 && <0.3,
+        random -any

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,4 @@
+resolver: lts-15.1
+packages:
+- .
+extra-deps: []


### PR DESCRIPTION
This is a backport of the benchmarks created for the version 1.2 proposal, prompted by https://github.com/haskell/random/pull/62#discussion_r439686457.

There are already benchmarks in this repository, but I consider them less reliable than what is proposed here.

To make it easier to see what is going on, it is split into three commits, all of which should pass CI.

1. The first commit copies `bench/Main.hs` from 84ff34c6cfa0d96087bed996ffe7768eb377dfd2, which is the state of `bench/Main.hs` after https://github.com/idontgetoutmuch/random/pull/150. This should pass CI because `bench/Main.hs` is not referenced in `random.cabal`.
2. The second commit backports `bench/Main.hs` to use the version 1.1 classes.
3. The third commit adds the benchmark to `random.cabal` and introduces a minimum `stack.yaml` to make it runnable via `stack bench random:bench`.

I have commented out `CBool` and `Natural` benchmarks because the relevant instances are missing from version 1.1, and I wanted to signal this.

The results on my machine are as follows (this is the time taken for 100000 iterations):

```console
$ .stack-work/dist/x86_64-linux-nix/Cabal-3.0.1.0/build/bench/bench --small
pure/random/Float                        mean 26.45 ms  ( +- 315.7 μs  )
pure/random/Double                       mean 47.95 ms  ( +- 466.0 μs  )
pure/random/Integer                      mean 40.78 ms  ( +- 1.082 ms  )
pure/random/Word8                        mean 14.00 ms  ( +- 547.1 μs  )
pure/random/Word16                       mean 13.91 ms  ( +- 357.6 μs  )
pure/random/Word32                       mean 21.81 ms  ( +- 918.6 μs  )
pure/random/Word64                       mean 43.81 ms  ( +- 1.845 ms  )
pure/random/Word                         mean 44.22 ms  ( +- 1.879 ms  )
pure/random/Int8                         mean 15.42 ms  ( +- 1.401 ms  )
pure/random/Int16                        mean 14.77 ms  ( +- 520.8 μs  )
pure/random/Int32                        mean 22.85 ms  ( +- 732.9 μs  )
pure/random/Int64                        mean 44.35 ms  ( +- 1.694 ms  )
pure/random/Int                          mean 44.52 ms  ( +- 1.550 ms  )
pure/random/Char                         mean 18.54 ms  ( +- 546.9 μs  )
pure/random/Bool                         mean 18.85 ms  ( +- 588.7 μs  )
pure/random/CChar                        mean 14.65 ms  ( +- 467.6 μs  )
pure/random/CSChar                       mean 14.72 ms  ( +- 555.2 μs  )
pure/random/CUChar                       mean 15.85 ms  ( +- 3.076 ms  )
pure/random/CShort                       mean 14.83 ms  ( +- 736.4 μs  )
pure/random/CUShort                      mean 14.33 ms  ( +- 1.063 ms  )
pure/random/CInt                         mean 22.55 ms  ( +- 566.5 μs  )
pure/random/CUInt                        mean 21.81 ms  ( +- 746.6 μs  )
pure/random/CLong                        mean 44.51 ms  ( +- 1.268 ms  )
pure/random/CULong                       mean 43.55 ms  ( +- 1.293 ms  )
pure/random/CPtrdiff                     mean 46.07 ms  ( +- 3.023 ms  )
pure/random/CSize                        mean 43.43 ms  ( +- 1.361 ms  )
pure/random/CWchar                       mean 24.04 ms  ( +- 1.853 ms  )
pure/random/CSigAtomic                   mean 23.52 ms  ( +- 636.2 μs  )
pure/random/CLLong                       mean 44.23 ms  ( +- 1.748 ms  )
pure/random/CULLong                      mean 44.37 ms  ( +- 1.423 ms  )
pure/random/CIntPtr                      mean 44.87 ms  ( +- 1.681 ms  )
pure/random/CUIntPtr                     mean 43.34 ms  ( +- 1.355 ms  )
pure/random/CIntMax                      mean 45.71 ms  ( +- 2.004 ms  )
pure/random/CUIntMax                     mean 43.49 ms  ( +- 1.109 ms  )
pure/randomR/full/Word8                  mean 18.04 ms  ( +- 732.6 μs  )
pure/randomR/full/Word16                 mean 18.00 ms  ( +- 626.8 μs  )
pure/randomR/full/Word32                 mean 28.70 ms  ( +- 964.4 μs  )
pure/randomR/full/Word64                 mean 52.47 ms  ( +- 1.797 ms  )
pure/randomR/full/Word                   mean 52.12 ms  ( +- 1.356 ms  )
pure/randomR/full/Int8                   mean 18.48 ms  ( +- 803.3 μs  )
pure/randomR/full/Int16                  mean 18.41 ms  ( +- 601.1 μs  )
pure/randomR/full/Int32                  mean 30.32 ms  ( +- 1.468 ms  )
pure/randomR/full/Int64                  mean 52.89 ms  ( +- 1.762 ms  )
pure/randomR/full/Int                    mean 52.78 ms  ( +- 1.773 ms  )
pure/randomR/full/Char                   mean 18.16 ms  ( +- 545.9 μs  )
pure/randomR/full/Bool                   mean 18.85 ms  ( +- 780.4 μs  )
pure/randomR/full/CChar                  mean 18.39 ms  ( +- 637.1 μs  )
pure/randomR/full/CSChar                 mean 18.46 ms  ( +- 591.9 μs  )
pure/randomR/full/CUChar                 mean 18.09 ms  ( +- 660.2 μs  )
pure/randomR/full/CShort                 mean 18.63 ms  ( +- 533.4 μs  )
pure/randomR/full/CUShort                mean 18.39 ms  ( +- 716.4 μs  )
pure/randomR/full/CInt                   mean 29.29 ms  ( +- 1.123 ms  )
pure/randomR/full/CUInt                  mean 29.22 ms  ( +- 1.320 ms  )
pure/randomR/full/CLong                  mean 54.15 ms  ( +- 3.550 ms  )
pure/randomR/full/CULong                 mean 52.40 ms  ( +- 1.704 ms  )
pure/randomR/full/CPtrdiff               mean 52.70 ms  ( +- 1.642 ms  )
pure/randomR/full/CSize                  mean 52.29 ms  ( +- 1.827 ms  )
pure/randomR/full/CWchar                 mean 29.16 ms  ( +- 884.1 μs  )
pure/randomR/full/CSigAtomic             mean 28.92 ms  ( +- 884.1 μs  )
pure/randomR/full/CLLong                 mean 52.91 ms  ( +- 1.926 ms  )
pure/randomR/full/CULLong                mean 52.28 ms  ( +- 1.504 ms  )
pure/randomR/full/CIntPtr                mean 53.26 ms  ( +- 2.146 ms  )
pure/randomR/full/CUIntPtr               mean 53.12 ms  ( +- 2.725 ms  )
pure/randomR/full/CIntMax                mean 56.11 ms  ( +- 2.420 ms  )
pure/randomR/full/CUIntMax               mean 52.53 ms  ( +- 2.029 ms  )
pure/randomR/excludeMax/Word8            mean 18.14 ms  ( +- 579.5 μs  )
pure/randomR/excludeMax/Word16           mean 18.05 ms  ( +- 641.3 μs  )
pure/randomR/excludeMax/Word32           mean 28.54 ms  ( +- 999.7 μs  )
pure/randomR/excludeMax/Word64           mean 48.63 ms  ( +- 1.503 ms  )
pure/randomR/excludeMax/Word             mean 48.19 ms  ( +- 1.491 ms  )
pure/randomR/excludeMax/Int8             mean 18.62 ms  ( +- 629.3 μs  )
pure/randomR/excludeMax/Int16            mean 18.56 ms  ( +- 609.6 μs  )
pure/randomR/excludeMax/Int32            mean 29.34 ms  ( +- 832.8 μs  )
pure/randomR/excludeMax/Int64            mean 49.87 ms  ( +- 1.692 ms  )
pure/randomR/excludeMax/Int              mean 49.93 ms  ( +- 1.723 ms  )
pure/randomR/excludeMax/Char             mean 18.17 ms  ( +- 690.9 μs  )
pure/randomR/excludeMax/Bool             mean 16.46 ms  ( +- 528.8 μs  )
pure/randomR/excludeMax/CChar            mean 18.45 ms  ( +- 578.7 μs  )
pure/randomR/excludeMax/CSChar           mean 18.50 ms  ( +- 468.5 μs  )
pure/randomR/excludeMax/CUChar           mean 17.99 ms  ( +- 750.6 μs  )
pure/randomR/excludeMax/CShort           mean 18.43 ms  ( +- 641.8 μs  )
pure/randomR/excludeMax/CUShort          mean 18.01 ms  ( +- 603.2 μs  )
pure/randomR/excludeMax/CInt             mean 29.20 ms  ( +- 964.2 μs  )
pure/randomR/excludeMax/CUInt            mean 28.63 ms  ( +- 750.7 μs  )
pure/randomR/excludeMax/CLong            mean 50.01 ms  ( +- 1.712 ms  )
pure/randomR/excludeMax/CULong           mean 48.54 ms  ( +- 1.565 ms  )
pure/randomR/excludeMax/CPtrdiff         mean 52.02 ms  ( +- 2.356 ms  )
pure/randomR/excludeMax/CSize            mean 48.76 ms  ( +- 1.608 ms  )
pure/randomR/excludeMax/CWchar           mean 29.13 ms  ( +- 1.049 ms  )
pure/randomR/excludeMax/CSigAtomic       mean 29.27 ms  ( +- 974.6 μs  )
pure/randomR/excludeMax/CLLong           mean 49.85 ms  ( +- 1.840 ms  )
pure/randomR/excludeMax/CULLong          mean 48.84 ms  ( +- 1.757 ms  )
pure/randomR/excludeMax/CIntPtr          mean 50.06 ms  ( +- 1.602 ms  )
pure/randomR/excludeMax/CUIntPtr         mean 48.81 ms  ( +- 1.901 ms  )
pure/randomR/excludeMax/CIntMax          mean 49.97 ms  ( +- 1.561 ms  )
pure/randomR/excludeMax/CUIntMax         mean 48.79 ms  ( +- 1.552 ms  )
pure/randomR/includeHalf/Word8           mean 18.50 ms  ( +- 569.8 μs  )
pure/randomR/includeHalf/Word16          mean 18.70 ms  ( +- 591.4 μs  )
pure/randomR/includeHalf/Word32          mean 30.78 ms  ( +- 2.567 ms  )
pure/randomR/includeHalf/Word64          mean 50.64 ms  ( +- 1.694 ms  )
pure/randomR/includeHalf/Word            mean 49.94 ms  ( +- 1.522 ms  )
pure/randomR/includeHalf/Int8            mean 19.02 ms  ( +- 549.3 μs  )
pure/randomR/includeHalf/Int16           mean 19.37 ms  ( +- 801.9 μs  )
pure/randomR/includeHalf/Int32           mean 29.89 ms  ( +- 475.8 μs  )
pure/randomR/includeHalf/Int64           mean 49.11 ms  ( +- 1.090 ms  )
pure/randomR/includeHalf/Int             mean 50.08 ms  ( +- 1.507 ms  )
pure/randomR/includeHalf/Char            mean 19.10 ms  ( +- 638.6 μs  )
pure/randomR/includeHalf/Bool            mean 17.31 ms  ( +- 803.3 μs  )
pure/randomR/includeHalf/CChar           mean 18.60 ms  ( +- 612.2 μs  )
pure/randomR/includeHalf/CSChar          mean 19.37 ms  ( +- 1.083 ms  )
pure/randomR/includeHalf/CUChar          mean 18.56 ms  ( +- 544.4 μs  )
pure/randomR/includeHalf/CShort          mean 18.60 ms  ( +- 589.7 μs  )
pure/randomR/includeHalf/CUShort         mean 18.50 ms  ( +- 559.2 μs  )
pure/randomR/includeHalf/CInt            mean 29.30 ms  ( +- 1.205 ms  )
pure/randomR/includeHalf/CUInt           mean 29.19 ms  ( +- 984.9 μs  )
pure/randomR/includeHalf/CLong           mean 49.72 ms  ( +- 1.639 ms  )
pure/randomR/includeHalf/CULong          mean 50.20 ms  ( +- 2.054 ms  )
pure/randomR/includeHalf/CPtrdiff        mean 49.66 ms  ( +- 1.493 ms  )
pure/randomR/includeHalf/CSize           mean 49.56 ms  ( +- 1.728 ms  )
pure/randomR/includeHalf/CWchar          mean 29.78 ms  ( +- 873.5 μs  )
pure/randomR/includeHalf/CSigAtomic      mean 29.47 ms  ( +- 979.5 μs  )
pure/randomR/includeHalf/CLLong          mean 53.02 ms  ( +- 4.087 ms  )
pure/randomR/includeHalf/CULLong         mean 50.81 ms  ( +- 1.965 ms  )
pure/randomR/includeHalf/CIntPtr         mean 49.69 ms  ( +- 1.662 ms  )
pure/randomR/includeHalf/CUIntPtr        mean 51.05 ms  ( +- 1.309 ms  )
pure/randomR/includeHalf/CIntMax         mean 49.88 ms  ( +- 1.660 ms  )
pure/randomR/includeHalf/CUIntMax        mean 49.55 ms  ( +- 1.616 ms  )
pure/randomR/unbounded/Float             mean 54.90 ms  ( +- 1.790 ms  )
pure/randomR/unbounded/Double            mean 81.42 ms  ( +- 2.483 ms  )
benchmarking pure/randomR/unbounded/Integer ... took 10.45 s, total 56 iterations
pure/randomR/unbounded/Integer           mean 193.2 ms  ( +- 6.872 ms  )
```

Related: https://github.com/idontgetoutmuch/random/pull/111.