### PR TITLE
Uniform for Generic 

### DIFF
--- a/random.cabal
+++ b/random.cabal
@@ -86,6 +86,8 @@ library
         System.Random
         System.Random.Internal
         System.Random.Stateful
+    other-modules:
+        System.Random.GFinite
 
     hs-source-dirs:   src
     default-language: Haskell2010

--- a/src/System/Random.hs
+++ b/src/System/Random.hs
@@ -27,6 +27,8 @@ module System.Random
   , Random(..)
   , Uniform
   , UniformRange
+  , Finite
+
   -- ** Standard pseudo-random number generator
   , StdGen
   , mkStdGen
@@ -64,6 +66,7 @@ import Data.Word
 import Foreign.C.Types
 import GHC.Exts
 import System.IO.Unsafe (unsafePerformIO)
+import System.Random.GFinite (Finite)
 import System.Random.Internal
 import qualified System.Random.SplitMix as SM
 

--- a/src/System/Random/GFinite.hs
+++ b/src/System/Random/GFinite.hs
@@ -31,9 +31,16 @@ data Cardinality
   | Card  !Integer
   deriving (Eq, Ord, Show)
 
+-- | This is needed only as a superclass of 'Integral'.
 instance Enum Cardinality where
   toEnum = fromIntegral
   fromEnum = fromIntegral
+  succ = (+ 1)
+  pred = subtract 1
+  enumFrom x           = map fromInteger (enumFrom (toInteger x))
+  enumFromThen x y     = map fromInteger (enumFromThen (toInteger x) (toInteger y))
+  enumFromTo x y       = map fromInteger (enumFromTo (toInteger x) (toInteger y))
+  enumFromThenTo x y z = map fromInteger (enumFromThenTo (toInteger x) (toInteger y) (toInteger z))
 
 instance Num Cardinality where
   fromInteger 1 = Shift 0  -- ()
@@ -54,6 +61,7 @@ instance Num Cardinality where
   signum = Card . signum . toInteger
   negate = Card . negate . toInteger
 
+-- | This is needed only as a superclass of 'Integral'.
 instance Real Cardinality where
   toRational = fromIntegral
 

--- a/src/System/Random/GFinite.hs
+++ b/src/System/Random/GFinite.hs
@@ -171,7 +171,7 @@ instance (GFinite a, GFinite b) => GFinite (a :*: b) where
   {-# INLINE toGFinite #-}
 
   fromGFinite (q :*: r) =
-    toInteger (gcardinality (proxy# :: Proxy# a) * Card (fromGFinite q)) + fromGFinite r
+    toInteger (gcardinality (proxy# :: Proxy# b) * Card (fromGFinite q)) + fromGFinite r
   {-# INLINE fromGFinite #-}
 
 instance Finite Void

--- a/src/System/Random/GFinite.hs
+++ b/src/System/Random/GFinite.hs
@@ -1,0 +1,272 @@
+-- |
+-- Module      :  System.Random.GFinite
+-- Copyright   :  (c) Andrew Lelechenko 2020
+-- License     :  BSD-style (see the file LICENSE in the 'random' repository)
+-- Maintainer  :  libraries@haskell.org
+--
+
+{-# LANGUAGE DefaultSignatures    #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE LambdaCase           #-}
+{-# LANGUAGE MagicHash            #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeOperators        #-}
+
+module System.Random.GFinite
+  ( Cardinality(..)
+  , Finite(..)
+  , GFinite(..)
+  ) where
+
+import Data.Bits
+import Data.Int
+import Data.Void
+import Data.Word
+import GHC.Exts (Proxy#, proxy#)
+import GHC.Generics
+
+-- | Cardinality of a set.
+data Cardinality
+  = Shift !Int -- ^ Shift n is equivalent to Card (bit n)
+  | Card  !Integer
+  deriving (Eq, Ord, Show)
+
+instance Enum Cardinality where
+  toEnum = fromIntegral
+  fromEnum = fromIntegral
+
+instance Num Cardinality where
+  fromInteger 1 = Shift 0  -- ()
+  fromInteger 2 = Shift 1  -- Bool
+  fromInteger n = Card n
+  {-# INLINE fromInteger #-}
+
+  x + y = fromInteger (toInteger x + toInteger y)
+  {-# INLINE (+) #-}
+
+  Shift x * Shift y = Shift (x + y)
+  Shift x * Card  y = Card (y `shiftL` x)
+  Card  x * Shift y = Card (x `shiftL` y)
+  Card  x * Card  y = Card (x * y)
+  {-# INLINE (*) #-}
+
+  abs    = Card . abs    . toInteger
+  signum = Card . signum . toInteger
+  negate = Card . negate . toInteger
+
+instance Real Cardinality where
+  toRational = fromIntegral
+
+instance Integral Cardinality where
+  toInteger = \case
+    Shift n -> bit n
+    Card  n -> n
+  {-# INLINE toInteger #-}
+
+  quotRem x' = \case
+    Shift n -> (Card (x `shiftR` n), Card (x .&. (bit n - 1)))
+    Card  n -> let (q, r) = x `quotRem` n in (Card q, Card r)
+    where
+      x = toInteger x'
+  {-# INLINE quotRem #-}
+
+-- | A type class for data with a finite number of inhabitants.
+-- This type class is used
+-- in default implementations of 'System.Random.Stateful.Uniform'
+-- and 'System.Random.Stateful.UniformRange'.
+--
+-- Users are not supposed to write instances of 'Finite' manually.
+-- There is a default implementation in terms of 'Generic' instead.
+--
+-- >>> :set -XDeriveGeneric -XDeriveAnyClass
+-- >>> import GHC.Generics (Generic)
+-- >>> data MyBool = MyTrue | MyFalse deriving (Generic, Finite)
+-- >>> data Action = Code MyBool | Eat (Maybe Bool) | Sleep deriving (Generic, Finite)
+--
+class Finite a where
+  cardinality :: Proxy# a -> Cardinality
+  toFinite :: Integer -> a
+  fromFinite :: a -> Integer
+
+  default cardinality :: (Generic a, GFinite (Rep a)) => Proxy# a -> Cardinality
+  cardinality _ = gcardinality (proxy# :: Proxy# (Rep a))
+
+  default toFinite :: (Generic a, GFinite (Rep a)) => Integer -> a
+  toFinite = to . toGFinite
+
+  default fromFinite :: (Generic a, GFinite (Rep a)) => a -> Integer
+  fromFinite = fromGFinite . from
+
+class GFinite f where
+  gcardinality :: Proxy# f -> Cardinality
+  toGFinite :: Integer -> f a
+  fromGFinite :: f a -> Integer
+
+instance GFinite V1 where
+  gcardinality _ = 0
+  {-# INLINE gcardinality #-}
+  toGFinite = const $ error "GFinite: V1 has no inhabitants"
+  {-# INLINE toGFinite #-}
+  fromGFinite = const $ error "GFinite: V1 has no inhabitants"
+  {-# INLINE fromGFinite #-}
+
+instance GFinite U1 where
+  gcardinality _ = 1
+  {-# INLINE gcardinality #-}
+  toGFinite = const U1
+  {-# INLINE toGFinite #-}
+  fromGFinite = const 0
+  {-# INLINE fromGFinite #-}
+
+instance Finite a => GFinite (K1 _x a) where
+  gcardinality _ = cardinality (proxy# :: Proxy# a)
+  {-# INLINE gcardinality #-}
+  toGFinite = K1 . toFinite
+  {-# INLINE toGFinite #-}
+  fromGFinite = fromFinite . unK1
+  {-# INLINE fromGFinite #-}
+
+instance GFinite a => GFinite (M1 _x _y a) where
+  gcardinality _ = gcardinality (proxy# :: Proxy# a)
+  {-# INLINE gcardinality #-}
+  toGFinite = M1 . toGFinite
+  {-# INLINE toGFinite #-}
+  fromGFinite = fromGFinite . unM1
+  {-# INLINE fromGFinite #-}
+
+instance (GFinite a, GFinite b) => GFinite (a :+: b) where
+  gcardinality _ =
+    gcardinality (proxy# :: Proxy# a) + gcardinality (proxy# :: Proxy# b)
+  {-# INLINE gcardinality #-}
+
+  toGFinite n
+    | n < cardA = L1 $ toGFinite n
+    | otherwise = R1 $ toGFinite (n - cardA)
+    where
+      cardA = toInteger (gcardinality (proxy# :: Proxy# a))
+  {-# INLINE toGFinite #-}
+
+  fromGFinite = \case
+     L1 x -> fromGFinite x
+     R1 x -> fromGFinite x + toInteger (gcardinality (proxy# :: Proxy# a))
+  {-# INLINE fromGFinite #-}
+
+instance (GFinite a, GFinite b) => GFinite (a :*: b) where
+  gcardinality _ =
+    gcardinality (proxy# :: Proxy# a) * gcardinality (proxy# :: Proxy# b)
+  {-# INLINE gcardinality #-}
+
+  toGFinite n = toGFinite (toInteger q) :*: toGFinite (toInteger r)
+    where
+      cardB = gcardinality (proxy# :: Proxy# b)
+      (q, r) = Card n `quotRem` cardB
+  {-# INLINE toGFinite #-}
+
+  fromGFinite (q :*: r) =
+    toInteger (gcardinality (proxy# :: Proxy# a) * Card (fromGFinite q)) + fromGFinite r
+  {-# INLINE fromGFinite #-}
+
+instance Finite Void
+instance Finite ()
+instance Finite Bool
+instance Finite Ordering
+
+instance Finite Char where
+  cardinality _ = Card $ toInteger (fromEnum (maxBound :: Char)) + 1
+  {-# INLINE cardinality #-}
+  toFinite = toEnum . fromInteger
+  {-# INLINE toFinite #-}
+  fromFinite = toInteger . fromEnum
+  {-# INLINE fromFinite #-}
+
+cardinalityDef :: forall a. (Num a, FiniteBits a) => Proxy# a -> Cardinality
+cardinalityDef _ = Shift (finiteBitSize (0 :: a))
+
+toFiniteDef :: forall a. (Num a, FiniteBits a) => Integer -> a
+toFiniteDef n
+    | isSigned (0 :: a) = fromInteger (n - bit (finiteBitSize (0 :: a) - 1))
+    | otherwise = fromInteger n
+
+fromFiniteDef :: (Integral a, FiniteBits a) => a -> Integer
+fromFiniteDef x
+    | isSigned x = toInteger x + bit (finiteBitSize x - 1)
+    | otherwise = toInteger x
+
+instance Finite Word8 where
+  cardinality = cardinalityDef
+  {-# INLINE cardinality #-}
+  toFinite = toFiniteDef
+  {-# INLINE toFinite #-}
+  fromFinite = fromFiniteDef
+  {-# INLINE fromFinite #-}
+instance Finite Word16 where
+  cardinality = cardinalityDef
+  {-# INLINE cardinality #-}
+  toFinite = toFiniteDef
+  {-# INLINE toFinite #-}
+  fromFinite = fromFiniteDef
+  {-# INLINE fromFinite #-}
+instance Finite Word32 where
+  cardinality = cardinalityDef
+  {-# INLINE cardinality #-}
+  toFinite = toFiniteDef
+  {-# INLINE toFinite #-}
+  fromFinite = fromFiniteDef
+  {-# INLINE fromFinite #-}
+instance Finite Word64 where
+  cardinality = cardinalityDef
+  {-# INLINE cardinality #-}
+  toFinite = toFiniteDef
+  {-# INLINE toFinite #-}
+  fromFinite = fromFiniteDef
+  {-# INLINE fromFinite #-}
+instance Finite Word where
+  cardinality = cardinalityDef
+  {-# INLINE cardinality #-}
+  toFinite = toFiniteDef
+  {-# INLINE toFinite #-}
+  fromFinite = fromFiniteDef
+  {-# INLINE fromFinite #-}
+instance Finite Int8 where
+  cardinality = cardinalityDef
+  {-# INLINE cardinality #-}
+  toFinite = toFiniteDef
+  {-# INLINE toFinite #-}
+  fromFinite = fromFiniteDef
+  {-# INLINE fromFinite #-}
+instance Finite Int16 where
+  cardinality = cardinalityDef
+  {-# INLINE cardinality #-}
+  toFinite = toFiniteDef
+  {-# INLINE toFinite #-}
+  fromFinite = fromFiniteDef
+  {-# INLINE fromFinite #-}
+instance Finite Int32 where
+  cardinality = cardinalityDef
+  {-# INLINE cardinality #-}
+  toFinite = toFiniteDef
+  {-# INLINE toFinite #-}
+  fromFinite = fromFiniteDef
+  {-# INLINE fromFinite #-}
+instance Finite Int64 where
+  cardinality = cardinalityDef
+  {-# INLINE cardinality #-}
+  toFinite = toFiniteDef
+  {-# INLINE toFinite #-}
+  fromFinite = fromFiniteDef
+  {-# INLINE fromFinite #-}
+instance Finite Int where
+  cardinality = cardinalityDef
+  {-# INLINE cardinality #-}
+  toFinite = toFiniteDef
+  {-# INLINE toFinite #-}
+  fromFinite = fromFiniteDef
+  {-# INLINE fromFinite #-}
+
+instance Finite a => Finite (Maybe a)
+instance (Finite a, Finite b) => Finite (Either a b)
+instance (Finite a, Finite b) => Finite (a, b)
+instance (Finite a, Finite b, Finite c) => Finite (a, b, c)
+instance (Finite a, Finite b, Finite c, Finite d) => Finite (a, b, c, d)
+instance (Finite a, Finite b, Finite c, Finite d, Finite e) => Finite (a, b, c, d, e)
+instance (Finite a, Finite b, Finite c, Finite d, Finite e, Finite f) => Finite (a, b, c, d, e, f)

--- a/src/System/Random/Internal.hs
+++ b/src/System/Random/Internal.hs
@@ -603,10 +603,13 @@ class UniformRange a where
   -- >>> import GHC.Generics (Generic)
   -- >>> import Data.Word (Word8)
   -- >>> import System.Random.Stateful
-  -- >>> data Foo = Bar Word8 | Quux Word8 deriving (Show, Generic, Finite, UniformRange)
   -- >>> gen <- newIOGenM (mkStdGen 42)
+  -- >>> data Foo = Bar Word8 | Quux Word8 deriving (Show, Generic, Finite, UniformRange)
   -- >>> Control.Monad.replicateM 10 (uniformRM (Bar 100, Quux 150) gen)
   -- [Bar 148,Bar 251,Bar 195,Quux 115,Quux 52,Bar 123,Bar 239,Bar 195,Quux 150,Quux 31]
+  -- >>> data Tuple = Tuple Bool Word8 deriving (Show, Generic, Finite, UniformRange)
+  -- >>> Control.Monad.replicateM 10 (uniformRM (Tuple False 100, Tuple True 150) gen)
+  -- [Tuple True 141,Tuple True 92,Tuple False 194,Tuple False 191,Tuple True 81,Tuple False 227,Tuple False 166,Tuple False 109,Tuple False 255,Tuple False 222]
   --
   -- @since 1.2.0
   uniformRM :: StatefulGen g m => (a, a) -> g -> m a

--- a/src/System/Random/Internal.hs
+++ b/src/System/Random/Internal.hs
@@ -838,6 +838,11 @@ instance UniformRange Char where
     word32ToChar <$> unbiasedWordMult32RM (charToWord32 l, charToWord32 h) g
   {-# INLINE uniformRM #-}
 
+instance Uniform () where
+  uniformM = const $ pure ()
+instance UniformRange () where
+  uniformRM = const $ const $ pure ()
+
 instance Uniform Bool where
   uniformM = fmap wordToBool . uniformWord8
     where wordToBool w = (w .&. 1) /= 0

--- a/src/System/Random/Internal.hs
+++ b/src/System/Random/Internal.hs
@@ -523,6 +523,11 @@ class Uniform a where
   default uniformM :: (StatefulGen g m, Generic a, GUniform (Rep a)) => g -> m a
   uniformM = fmap to . (`runContT` pure) . guniformM
 
+-- | Default implementation of Uniform type class in terms
+-- generics. Note use of ContT. Without it uses of fmap and bind are
+-- fully polymorphic and GHC can't inline or specialize it. ContT
+-- makes fmap and binds used in @gniformM@ monomorphic so GHC able to
+-- specialize code instance reasonably close to handwritten one
 class GUniform f where
   guniformM :: StatefulGen g m => g -> ContT r m (f a)
 

--- a/src/System/Random/Internal.hs
+++ b/src/System/Random/Internal.hs
@@ -523,11 +523,12 @@ class Uniform a where
   default uniformM :: (StatefulGen g m, Generic a, GUniform (Rep a)) => g -> m a
   uniformM = fmap to . (`runContT` pure) . guniformM
 
--- | Default implementation of Uniform type class in terms
--- generics. Note use of ContT. Without it uses of fmap and bind are
--- fully polymorphic and GHC can't inline or specialize it. ContT
--- makes fmap and binds used in @gniformM@ monomorphic so GHC able to
--- specialize code instance reasonably close to handwritten one
+-- | Default implementation of 'Uniform' type class for 'Generic' data.
+-- It's important to use 'ContT', because without it 'fmap' and '>>=' remain
+-- polymorphic too long and GHC fails to inline or specialize it, ending up
+-- building full 'Rep' a structure in memory. 'ContT'
+-- makes 'fmap' and '>>=' used in 'guniformM' monomorphic, so GHC is able to
+-- specialize 'Generic' instance reasonably close to a handwritten one.
 class GUniform f where
   guniformM :: StatefulGen g m => g -> ContT r m (f a)
 

--- a/src/System/Random/Internal.hs
+++ b/src/System/Random/Internal.hs
@@ -90,7 +90,7 @@ import GHC.IO (IO(..))
 import GHC.Word
 import Numeric.Natural (Natural)
 import System.IO.Unsafe (unsafePerformIO)
-import System.Random.GFinite (Cardinality(..), Finite(..), GFinite(..))
+import System.Random.GFinite (Cardinality(..), GFinite(..))
 import qualified System.Random.SplitMix as SM
 import qualified System.Random.SplitMix32 as SM32
 #if __GLASGOW_HASKELL__ >= 800
@@ -597,25 +597,8 @@ class UniformRange a where
   --
   -- > uniformRM (a, b) = uniformRM (b, a)
   --
-  -- There is a default implementation for finitely-inhabited types.
-  --
-  -- >>> :set -XDeriveGeneric -XDeriveAnyClass
-  -- >>> import GHC.Generics (Generic)
-  -- >>> import Data.Word (Word8)
-  -- >>> import System.Random.Stateful
-  -- >>> gen <- newIOGenM (mkStdGen 42)
-  -- >>> data Foo = Bar Word8 | Quux Word8 deriving (Show, Generic, Finite, UniformRange)
-  -- >>> Control.Monad.replicateM 10 (uniformRM (Bar 100, Quux 150) gen)
-  -- [Bar 148,Bar 251,Bar 195,Quux 115,Quux 52,Bar 123,Bar 239,Bar 195,Quux 150,Quux 31]
-  -- >>> data Tuple = Tuple Bool Word8 deriving (Show, Generic, Finite, UniformRange)
-  -- >>> Control.Monad.replicateM 10 (uniformRM (Tuple False 100, Tuple True 150) gen)
-  -- [Tuple True 141,Tuple True 92,Tuple False 194,Tuple False 191,Tuple True 81,Tuple False 227,Tuple False 166,Tuple False 109,Tuple False 255,Tuple False 222]
-  --
   -- @since 1.2.0
   uniformRM :: StatefulGen g m => (a, a) -> g -> m a
-
-  default uniformRM :: (StatefulGen g m, Finite a) => (a, a) -> g -> m a
-  uniformRM (l, h) = fmap toFinite . uniformIntegralM (fromFinite l, fromFinite h)
 
 instance UniformRange Integer where
   uniformRM = uniformIntegralM

--- a/src/System/Random/Stateful.hs
+++ b/src/System/Random/Stateful.hs
@@ -70,6 +70,7 @@ module System.Random.Stateful
   -- $uniform
   , Uniform(..)
   , uniformListM
+  , uniformViaFiniteM
   , UniformRange(..)
 
   -- * Generators for sequences of pseudo-random bytes

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -70,11 +70,6 @@ main =
     , integralSpec (Proxy :: Proxy CUIntMax)
     , integralSpec (Proxy :: Proxy Integer)
     , integralSpec (Proxy :: Proxy Natural)
-#if __GLASGOW_HASKELL__ >= 802
-    , integralSpec (Proxy :: Proxy MyBool)
-    , integralSpec (Proxy :: Proxy MyAction)
-    , integralSpec (Proxy :: Proxy Foo)
-#endif
     , runSpec
     , floatTests
     , byteStringSpec
@@ -154,11 +149,11 @@ seeded f = f . mkStdGen
 #if __GLASGOW_HASKELL__ >= 802
 
 data MyBool = MyTrue | MyFalse
-  deriving (Eq, Ord, Show, Generic, Finite, Uniform, UniformRange)
+  deriving (Eq, Ord, Show, Generic, Finite, Uniform)
 instance Monad m => Serial m MyBool
 
 data MyAction = Code (Maybe MyBool) | Never Void | Eat (Bool, Bool) | Sleep ()
-  deriving (Eq, Ord, Show, Generic, Finite, Uniform, UniformRange)
+  deriving (Eq, Ord, Show, Generic, Finite, Uniform)
 instance Monad m => Serial m MyAction
 
 data Foo
@@ -169,7 +164,7 @@ data Foo
   | Bar32 Int32 | Baz32 Word32
   | Bar64 Int64 | Baz64 Word64
   | Final ()
-  deriving (Eq, Ord, Show, Generic, Finite, Uniform, UniformRange)
+  deriving (Eq, Ord, Show, Generic, Finite, Uniform)
 instance Monad m => Serial m Foo
 
 #endif

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -146,15 +146,14 @@ runSpec = testGroup "runGenState_ and runPrimGenIO_"
 seeded :: (StdGen -> a) -> Int -> a
 seeded f = f . mkStdGen
 
-#if __GLASGOW_HASKELL__ >= 802
-
 data MyBool = MyTrue | MyFalse
   deriving (Eq, Ord, Show, Generic, Finite, Uniform)
 instance Monad m => Serial m MyBool
 
 data MyAction = Code (Maybe MyBool) | Never Void | Eat (Bool, Bool) | Sleep ()
-  deriving (Eq, Ord, Show, Generic, Finite, Uniform)
+  deriving (Eq, Ord, Show, Generic, Finite)
 instance Monad m => Serial m MyAction
+instance Uniform MyAction
 
 data Foo
   = Quux Char
@@ -166,5 +165,3 @@ data Foo
   | Final ()
   deriving (Eq, Ord, Show, Generic, Finite, Uniform)
 instance Monad m => Serial m Foo
-
-#endif

--- a/test/doctests.hs
+++ b/test/doctests.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 module Main where
 
-#if __GLASGOW_HASKELL__ >= 802
+#if __GLASGOW_HASKELL__ >= 802 && __GLASGOW_HASKELL__ != 810
 
 import Test.DocTest (doctest)
 


### PR DESCRIPTION
Cf. #21 and partially #26 

```haskell
> :set -XDeriveGeneric -XDeriveAnyClass
> import GHC.Generics (Generic)
> data Action = Code Bool | Eat (Maybe Bool) | Sleep deriving (Show, Generic, Uniform)
> gen <- newIOGenM (mkStdGen 42)
> uniformListM 10 gen :: IO [Action]
[Code False,Code False,Eat Nothing,Code True,Eat (Just False),Eat (Just True),Eat Nothing,Eat (Just False),Sleep,Code True]
```