### PR TITLE
Allow deriving Uniform and UniformRange instances using DerivingVia

### DIFF
--- a/src/System/Random.hs
+++ b/src/System/Random.hs
@@ -27,6 +27,7 @@ module System.Random
   , Random(..)
   , Uniform
   , UniformRange
+  , UniformEnum
   -- ** Standard pseudo-random number generator
   , StdGen
   , mkStdGen

--- a/src/System/Random/Internal.hs
+++ b/src/System/Random/Internal.hs
@@ -1052,10 +1052,12 @@ instance (Uniform a, Uniform b, Uniform c, Uniform d, Uniform e, Uniform f, Unif
 newtype UniformEnum a = UniformEnum a
 
 instance Enum a => UniformRange (UniformEnum a) where
-  uniformM = error "Unimplemented"
+  uniformRM (UniformEnum l, UniformEnum h) g =
+    pure . UniformEnum . toEnum =<< uniformIntegralM (fromEnum l, fromEnum h) g
 
 instance (Bounded a, Enum a) => Uniform (UniformEnum a) where
-  uniformRM = error "Unimplemented"
+  uniformM g = pure . UniformEnum . toEnum
+    =<< uniformIntegralM (fromEnum (minBound :: a), fromEnum (maxBound :: a)) g
 
 -- Appendix 1.
 --

--- a/src/System/Random/Internal.hs
+++ b/src/System/Random/Internal.hs
@@ -1049,6 +1049,16 @@ instance (Uniform a, Uniform b, Uniform c, Uniform d, Uniform e, Uniform f, Unif
 -- DerivingVia 'Uniform' and 'UniformRange' instances for Enums
 -------------------------------------------------------------------------------
 
+-- | Newtype for use with @DerivingVia@. Enables deriving instances of
+-- @UniformRange@ for types with @Enum@ instances, and @Uniform@ for
+-- types with @Bounded@ and @Enum@ instances.
+--
+-- ====__Example__
+--
+--     data RGB = R | G | B
+--       deriving (Enum, Bounded)
+--       deriving Uniform via UniformEnum RGB
+--
 newtype UniformEnum a = UniformEnum a
 
 instance Enum a => UniformRange (UniformEnum a) where

--- a/src/System/Random/Internal.hs
+++ b/src/System/Random/Internal.hs
@@ -1045,6 +1045,18 @@ instance (Uniform a, Uniform b, Uniform c, Uniform d, Uniform e, Uniform f) => U
 instance (Uniform a, Uniform b, Uniform c, Uniform d, Uniform e, Uniform f, Uniform g) => Uniform (a, b, c, d, e, f, g) where
   uniformM g = (,,,,,,) <$> uniformM g <*> uniformM g <*> uniformM g <*> uniformM g <*> uniformM g <*> uniformM g <*> uniformM g
 
+-------------------------------------------------------------------------------
+-- DerivingVia 'Uniform' and 'UniformRange' instances for Enums
+-------------------------------------------------------------------------------
+
+newtype UniformEnum a = UniformEnum a
+
+instance Enum a => UniformRange (UniformEnum a) where
+  uniformM = error "Unimplemented"
+
+instance (Bounded a, Enum a) => Uniform (UniformEnum a) where
+  uniformRM = error "Unimplemented"
+
 -- Appendix 1.
 --
 -- @top@ and @bottom@ are signed integers of bit width @n@. @toUnsigned@

--- a/src/System/Random/Internal.hs
+++ b/src/System/Random/Internal.hs
@@ -58,6 +58,7 @@ module System.Random.Internal
   , uniformDoublePositive01M
   , uniformFloat01M
   , uniformFloatPositive01M
+  , UniformEnum
 
   -- * Generators for sequences of pseudo-random bytes
   , genShortByteStringIO


### PR DESCRIPTION
This solution was proposed by @Shimuuar on [#21](https://github.com/haskell/random/issues/21#issuecomment-649094523).

Essentially, this should allow users of the random library to get `Uniform` and `UniformRange` instances for free, using `DerivingVia`

## Usage (basically copied from @Shimuuar's comment):

```haskell
{-# LANGUAGE DerivingVia #-}

data RGB = R | G | B
  deriving (Enum, Bounded)
  deriving Uniform via UniformEnum RGB
```