### PR TITLE
Fix spelling of __GLASGOW_HASKELL__ macro

### DIFF
--- a/src/System/Random.hs
+++ b/src/System/Random.hs
@@ -265,7 +265,7 @@ instance Random Word8
 instance Random Word16
 instance Random Word32
 instance Random Word64
-#if __GLASGOW_HASKELL >= 802
+#if __GLASGOW_HASKELL__ >= 802
 instance Random CBool
 #endif
 instance Random CChar

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -42,7 +42,7 @@ main =
     , integralSpec (Proxy :: Proxy Int)
     , integralSpec (Proxy :: Proxy Char)
     , integralSpec (Proxy :: Proxy Bool)
-#if __GLASGOW_HASKELL >= 802
+#if __GLASGOW_HASKELL__ >= 802
     , integralSpec (Proxy :: Proxy CBool)
 #endif
     , integralSpec (Proxy :: Proxy CChar)


### PR DESCRIPTION
While we are stuck with #73, I'd like to fix this in a separate PR. Hope it's a no-brainer.