### PR TITLE
Add UniformRange.isInRange function

### DIFF
--- a/src/System/Random/Internal.hs
+++ b/src/System/Random/Internal.hs
@@ -597,8 +597,43 @@ class UniformRange a where
   --
   -- > uniformRM (a, b) = uniformRM (b, a)
   --
+  -- The range is understood as defined by means of 'isInRange', so
+  --
+  -- > isInRange (a, b) <$> uniformRM (a, b) gen == pure True
+  --
+  -- but beware of
+  -- [floating point number caveats](System-Random-Stateful.html#fpcaveats).
+  --
   -- @since 1.2.0
   uniformRM :: StatefulGen g m => (a, a) -> g -> m a
+
+  -- | A notion of (inclusive) ranges prescribed to @a@.
+  --
+  -- Ranges are symmetric:
+  --
+  -- > isInRange (lo, hi) x == isInRange (hi, lo) x
+  --
+  -- Ranges include their endpoints:
+  --
+  -- > isInRange (lo, hi) lo == True
+  --
+  -- Ranges are transitive relations:
+  --
+  -- > isInRange (lo, hi) mid && isInRange (lo, mid) x ==> isInRange (lo, hi) x
+  --
+  -- Ranges are injective (up to symmetry), which means that
+  -- ranges between different endpoints cannot be the same:
+  --
+  -- > (a, b) == (c, d) || (a, b) == (d, c) ||
+  -- > there exists x such that
+  -- >    isInRange (a, b) x && not (isInRange (c, d) x)
+  -- > || isInRange (c, d) x && not (isInRange (a, b) x)
+  --
+  -- @since 1.3.0
+  isInRange :: (a, a) -> a -> Bool
+
+  default isInRange :: Ord a => (a, a) -> a -> Bool
+  isInRange (a, b) x = min a b <= x && x <= max a b
 
 instance UniformRange Integer where
   uniformRM = uniformIntegralM

--- a/src/System/Random/Internal.hs
+++ b/src/System/Random/Internal.hs
@@ -621,6 +621,11 @@ class UniformRange a where
   --
   -- > isInRange (x, x) y == x == y
   --
+  -- Endpoints are endpoints:
+  --
+  -- > isInRange (lo, hi) x ==>
+  -- > isInRange (lo, x) hi == x == hi
+  --
   -- Ranges are transitive relations:
   --
   -- > isInRange (lo, hi) lo' && isInRange (lo, hi) hi' &&

--- a/src/System/Random/Internal.hs
+++ b/src/System/Random/Internal.hs
@@ -628,8 +628,8 @@ class UniformRange a where
   --
   -- Ranges are transitive relations:
   --
-  -- > isInRange (lo, hi) lo' && isInRange (lo, hi) hi' &&
-  -- > && isInRange (lo', hi') x ==> isInRange (lo, hi) x
+  -- > isInRange (lo, hi) lo' && isInRange (lo, hi) hi' && isInRange (lo', hi') x
+  -- > ==> isInRange (lo, hi) x
   --
   -- @since 1.3.0
   isInRange :: (a, a) -> a -> Bool

--- a/src/System/Random/Internal.hs
+++ b/src/System/Random/Internal.hs
@@ -617,17 +617,14 @@ class UniformRange a where
   --
   -- > isInRange (lo, hi) lo == True
   --
+  -- When endpoints coincide, there is nothing else:
+  --
+  -- > isInRange (x, x) y == x == y
+  --
   -- Ranges are transitive relations:
   --
-  -- > isInRange (lo, hi) mid && isInRange (lo, mid) x ==> isInRange (lo, hi) x
-  --
-  -- Ranges are injective (up to symmetry), which means that
-  -- ranges between different endpoints cannot be the same:
-  --
-  -- > (a, b) == (c, d) || (a, b) == (d, c) ||
-  -- > there exists x such that
-  -- >    isInRange (a, b) x && not (isInRange (c, d) x)
-  -- > || isInRange (c, d) x && not (isInRange (a, b) x)
+  -- > isInRange (lo, hi) lo' && isInRange (lo, hi) hi' &&
+  -- > && isInRange (lo', hi') x ==> isInRange (lo, hi) x
   --
   -- @since 1.3.0
   isInRange :: (a, a) -> a -> Bool


### PR DESCRIPTION
Following our discussions earlier, here is my proposal for a new `isInRange` function to describe rigorously what exactly `UniformRange` instance means by "range". This will allow us to define lawful `UniformRange` instances for tuples and complex numbers. 