### PR TITLE
Fix typo of uniformByteStringM

### DIFF
--- a/src/System/Random.hs
+++ b/src/System/Random.hs
@@ -174,7 +174,7 @@ uniformR :: (RandomGen g, UniformRange a) => (a, a) -> g -> (a, g)
 uniformR r g = runStateGen g (uniformRM r)
 
 -- | Generates a 'ByteString' of the specified size using a pure pseudo-random
--- number generator. See 'uniformByteString' for the monadic version.
+-- number generator. See 'uniformByteStringM' for the monadic version.
 --
 -- ====__Examples__
 --


### PR DESCRIPTION
It appears this intended to reference `uniformByteStringM`, which is used in the code a few lines below. I searched google and stackage and didn't find a `uniformByteString` so I assume it was just a typo