### PR TITLE
WIP: Improve `RandomGenM` interface:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.3.0
+
+* Improve `RandomGenM` interface:
+
+   * Add a new class method `newRandomGenM`, which also allowed addition
+     of `splitRandomGenM`
+   * Add `getGenM` and getGenM`
+
+
 # 1.2.0
 
 1. Breaking change which mostly maintains backwards compatibility, see


### PR DESCRIPTION
* Add a new class method `newRandomGenM`, which also allowed addition
  of `splitRandomGenM`
* Add `getGenM` and getGenM`


This is still work-in-progress, because I want to add some tests and examples for `RandomGenM` interface.

This is essentially a more general version of the global StdGen, i.e. `getStdGen`, `setStdGen`.