### PR TITLE
WIP: Implement safetey around non-splittable PRNGs

### DIFF
--- a/src/System/Random/Stateful.hs
+++ b/src/System/Random/Stateful.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -225,7 +226,7 @@ class (RandomGen r, StatefulGen g m) => RandomGenM g r m | g -> r where
 -- wrapper with one of the resulting generators and returns the other.
 --
 -- @since 1.2.0
-splitGenM :: RandomGenM g r m => g -> m r
+splitGenM :: forall r g m. (Splittable r, RandomGenM g r m) => g -> m r
 splitGenM = applyRandomGenM split
 
 instance (RandomGen r, MonadIO m) => RandomGenM (IOGenM r) r m where


### PR DESCRIPTION
I think I figured out an elegant solution for differentiating splittable vs non-splittable PRNGs in a type safe way with very little breakage!!!

CC @idontgetoutmuch and @curiousleo We've discussed the problem here at some lengths: idontgetoutmuch/random#7

This is the change to the type class:

```haskell
class RandomGen g where
  type Splittable g :: Bool
  type Splittable g = 'True
  ...
  split :: Splittable g ~ 'True => g -> (g, g)
```


Which means only instances for PRNGs that are non splittable need to be adjusted, eg:
```haskell
instance RandomGen PureMT where
   type Splittable PureMT = TypeError ('Text "PureMT is not a splittable PRNG")
   split = error "System.Random.Mersenne.Pure: unable to split the mersenne twister"
```

which if you try to use `split` function, will give you a nice error message:

```haskell
impossibleSplit :: IO (PureMT, PureMT)
impossibleSplit = split <$> newPureMT
```

```
    • PureMT is not a splittable PRNG
    • In the first argument of ‘(<$>)’, namely ‘split’
      In the expression: split <$> newPureMT
      In an equation for ‘impossibleSplit’:
          impossibleSplit = split <$> newPureMT
   |
Compilation failed.
```

Instead of this ugly runtime error:
```
*** Exception: System.Random.Mersenne.Pure: unable to split the mersenne twister
CallStack (from HasCallStack):
```