### PR TITLE
make Uniform/UniformRange newtype-derivable

### DIFF
--- a/random.cabal
+++ b/random.cabal
@@ -155,6 +155,7 @@ test-suite spec
     build-depends:
         base -any,
         bytestring -any,
+        mtl,
         random -any,
         smallcheck >=1.2 && <1.3,
         tasty >=1.0 && <1.5,

--- a/src/System/Random.hs
+++ b/src/System/Random.hs
@@ -27,6 +27,7 @@ module System.Random
   , Random(..)
   , Uniform
   , UniformRange
+  , UniformEnum(..)
   , Finite
 
   -- ** Standard pseudo-random number generator
@@ -59,6 +60,7 @@ module System.Random
 
 import Control.Arrow
 import Control.Monad.IO.Class
+import Control.Monad.State.Strict (StateT(..))
 import Data.ByteString (ByteString)
 import Data.Int
 import Data.IORef

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -6,6 +6,12 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+#if __GLASGOW_HASKELL__ >= 806
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE StandaloneDeriving #-}
+#endif
 module Main (main) where
 
 import Data.ByteString.Short as SBS
@@ -179,3 +185,13 @@ newtype ConstGen = ConstGen Word64
 instance RandomGen ConstGen where
   genWord64 g@(ConstGen c) = (c, g)
   split g = (g, g)
+
+#if __GLASGOW_HASKELL__ >= 806
+newtype MyInt = MyInt Int
+deriving newtype instance UniformRange MyInt
+
+data Things = This | That | Those | These
+  deriving stock (Eq, Ord, Enum, Bounded)
+deriving via UniformEnum Things instance UniformRange Things
+deriving via UniformEnum Things instance Uniform Things
+#endif

--- a/test/Spec/Range.hs
+++ b/test/Spec/Range.hs
@@ -7,6 +7,7 @@ module Spec.Range
   , uniformRangeWithinExcludedD
   ) where
 
+import Control.Monad.State.Strict (StateT(..))
 import System.Random.Internal
 import System.Random.Stateful
 import Data.Proxy

--- a/test/Spec/Run.hs
+++ b/test/Spec/Run.hs
@@ -1,5 +1,6 @@
 module Spec.Run (runsEqual) where
 
+import Control.Monad.State.Strict (StateT(..))
 import Data.Word (Word64)
 import System.Random.Stateful
 

--- a/test/doctests.hs
+++ b/test/doctests.hs
@@ -6,7 +6,11 @@ module Main where
 import Test.DocTest (doctest)
 
 main :: IO ()
-main = doctest ["src"]
+main = doctest [
+#if __GLASGOW_HASKELL__ >= 806
+  "-XQuantifiedConstraints",
+#endif
+  "src" ]
 
 #else
 


### PR DESCRIPTION
Allows to newtype-derive `Uniform`/`UniformRange` on GHC 8.6+, using `QuantifiedConstraints` (similar to [this](https://ryanglscott.github.io/2018/03/04/how-quantifiedconstraints-can-let-us-put-join-back-in-monad/)).

Also allows `DerivingVia`, applicable to #92. As an example, we revive #71.

 - For some reason, it only works with `StandaloneDeriving`.
 - `RepLike` might not be the best name. Should `RepLike` be exported, even though that is not strictly necessary?
 - On GHC < 8.6, there will be "unused import" warnings about `StateT` (we need the constructor to be available for `Coercible` instances). Could resolve with more CPP.
 - Missing documentation (will add if desired).

Feel free to close this if you think this is not worth it.
