### PR TITLE
Add `globalStdGen`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.2.1
 
+* Add `globalStdGen`
 * Addition of `initStdGen`
 
 # 1.2.0

--- a/src/System/Random.hs
+++ b/src/System/Random.hs
@@ -66,7 +66,6 @@ import Data.IORef
 import Data.Word
 import Foreign.C.Types
 import GHC.Exts
-import System.IO.Unsafe (unsafePerformIO)
 import System.Random.GFinite (Finite)
 import System.Random.Internal
 import qualified System.Random.SplitMix as SM
@@ -366,10 +365,6 @@ setStdGen = liftIO . writeIORef theStdGen
 -- |Gets the global pseudo-random number generator.
 getStdGen :: MonadIO m => m StdGen
 getStdGen = liftIO $ readIORef theStdGen
-
-theStdGen :: IORef StdGen
-theStdGen = unsafePerformIO $ SM.initSMGen >>= newIORef . StdGen
-{-# NOINLINE theStdGen #-}
 
 -- |Applies 'split' to the current global pseudo-random generator,
 -- updates it with one of the results, and returns the other.

--- a/src/System/Random/Internal.hs
+++ b/src/System/Random/Internal.hs
@@ -17,8 +17,8 @@
 #if __GLASGOW_HASKELL__ >= 800
 {-# LANGUAGE TypeFamilyDependencies #-}
 #else
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE TypeFamilies #-}
 #endif
 {-# OPTIONS_HADDOCK hide, not-home #-}
 
@@ -39,6 +39,7 @@ module System.Random.Internal
   -- ** Standard pseudo-random number generator
   , StdGen(..)
   , mkStdGen
+  , theStdGen
 
   -- * Monadic adapters for pure pseudo-random number generators
   -- ** Pure adapter
@@ -75,12 +76,13 @@ import Control.Monad.Cont (ContT, runContT)
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.ST
 import Control.Monad.ST.Unsafe
-import Control.Monad.State.Strict (StateT(..), State, MonadState(..), runState)
+import Control.Monad.State.Strict (MonadState(..), State, StateT(..), runState)
 import Control.Monad.Trans (lift)
 import Data.Bits
 import Data.ByteString.Builder.Prim (word64LE)
 import Data.ByteString.Builder.Prim.Internal (runF)
 import Data.ByteString.Short.Internal (ShortByteString(SBS), fromShort)
+import Data.IORef (IORef, newIORef)
 import Data.Int
 import Data.Word
 import Foreign.C.Types
@@ -532,6 +534,12 @@ instance RandomGen SM32.SMGen where
 -- | Constructs a 'StdGen' deterministically.
 mkStdGen :: Int -> StdGen
 mkStdGen = StdGen . SM.mkSMGen . fromIntegral
+
+-- | Global mutable veriable with `StdGen`
+theStdGen :: IORef StdGen
+theStdGen = unsafePerformIO $ SM.initSMGen >>= newIORef . StdGen
+{-# NOINLINE theStdGen #-}
+
 
 -- | The class of types for which a uniformly distributed value can be drawn
 -- from all possible values of the type.

--- a/src/System/Random/Stateful.hs
+++ b/src/System/Random/Stateful.hs
@@ -36,6 +36,7 @@ module System.Random.Stateful
   , randomM
   , randomRM
   , splitGenM
+  , globalStdGen
 
   -- * Monadic adapters for pure pseudo-random number generators #monadicadapters#
   -- $monadicadapters
@@ -334,6 +335,18 @@ newtype AtomicGen g = AtomicGen { unAtomicGen :: g}
 newAtomicGenM :: MonadIO m => g -> m (AtomicGenM g)
 newAtomicGenM = fmap AtomicGenM . liftIO . newIORef
 
+
+-- | Global mutable standard pseudo-random number generator. This is the same
+-- generator that was historically used by `randomIO` and `randomRIO` functions.
+--
+-- >>> replicateM 10 (uniformRM ('a', 'z') globalStdGen)
+-- "tdzxhyfvgr"
+--
+-- @since 1.2.1
+globalStdGen :: AtomicGenM StdGen
+globalStdGen = AtomicGenM theStdGen
+
+
 instance (RandomGen g, MonadIO m) => StatefulGen (AtomicGenM g) m where
   uniformWord32R r = applyAtomicGen (genWord32R r)
   {-# INLINE uniformWord32R #-}
@@ -367,7 +380,7 @@ instance (RandomGen g, MonadIO m) => FrozenGen (AtomicGen g) m where
 -- 7879794327570578227
 --
 -- @since 1.2.0
-applyAtomicGen :: MonadIO m => (g -> (a, g)) -> (AtomicGenM g) -> m a
+applyAtomicGen :: MonadIO m => (g -> (a, g)) -> AtomicGenM g -> m a
 applyAtomicGen op (AtomicGenM gVar) =
   liftIO $ atomicModifyIORef' gVar $ \g ->
     case op g of
@@ -406,6 +419,8 @@ newtype IOGen g = IOGen { unIOGen :: g }
 -- @since 1.2.0
 newIOGenM :: MonadIO m => g -> m (IOGenM g)
 newIOGenM = fmap IOGenM . liftIO . newIORef
+
+
 
 instance (RandomGen g, MonadIO m) => StatefulGen (IOGenM g) m where
   uniformWord32R r = applyIOGen (genWord32R r)
@@ -715,6 +730,7 @@ runSTGen_ g action = fst $ runSTGen g action
 -- $setup
 -- >>> import Control.Monad.Primitive
 -- >>> import qualified System.Random.MWC as MWC
+-- >>> writeIORef theStdGen $ mkStdGen 2021
 --
 -- >>> :set -XFlexibleContexts
 -- >>> :set -XFlexibleInstances


### PR DESCRIPTION
There is no reason why we can't use the global stdGen with the new stateful interface.