### PR TITLE
Improve uniform ShortByteString (fixup)

### DIFF
--- a/bench-legacy/SimpleRNGBench.hs
+++ b/bench-legacy/SimpleRNGBench.hs
@@ -222,7 +222,7 @@ main = do
       randBool    = random :: RandomGen g => g -> (Bool,g)
       randChar    = random :: RandomGen g => g -> (Char,g)
 
-      gen = mkStdGen 23852358661234
+      gen = mkStdGen 238523586
       gamut th = do
         putStrLn "  First, timing System.Random.next:"
         timeit th freq "constant zero gen"      NoopRNG next

--- a/random.cabal
+++ b/random.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               random
-version:            1.2.0
+version:            1.2.1
 license:            BSD3
 license-file:       LICENSE
 maintainer:         core-libraries-committee@haskell.org

--- a/random.cabal
+++ b/random.cabal
@@ -126,9 +126,9 @@ test-suite legacy-test
         ghc-options:
             -Wno-deprecations
     build-depends:
-        base -any,
+        base,
         containers >=0.5 && <0.7,
-        random -any
+        random
 
 test-suite doctests
     type:             exitcode-stdio-1.0
@@ -136,11 +136,11 @@ test-suite doctests
     hs-source-dirs:   test
     default-language: Haskell2010
     build-depends:
-        base -any,
+        base,
         doctest >=0.15 && <0.19,
         mwc-random >=0.13 && <0.16,
         primitive >=0.6 && <0.8,
-        random -any,
+        random,
         unliftio >=0.2 && <0.3,
         vector >= 0.10 && <0.14
 
@@ -155,9 +155,9 @@ test-suite spec
     default-language: Haskell2010
     ghc-options:      -Wall
     build-depends:
-        base -any,
-        bytestring -any,
-        random -any,
+        base,
+        bytestring,
+        random,
         smallcheck >=1.2 && <1.3,
         tasty >=1.0 && <1.5,
         tasty-smallcheck >=0.8 && <0.9,
@@ -174,8 +174,8 @@ test-suite spec-inspection
     default-language: Haskell2010
     ghc-options:      -Wall
     build-depends:
-        base -any,
-        random -any,
+        base,
+        random,
         tasty >=1.0 && <1.5
     if impl(ghc >= 8.0)
         build-depends:
@@ -196,9 +196,9 @@ benchmark legacy-bench
             -Wno-deprecations
 
     build-depends:
-        base -any,
-        random -any,
-        rdtsc -any,
+        base,
+        random,
+        rdtsc,
         split >=0.2 && <0.3,
         time >=1.4 && <1.11
 
@@ -209,9 +209,9 @@ benchmark bench
     default-language: Haskell2010
     ghc-options:      -Wall -O2
     build-depends:
-        base -any,
+        base,
         mtl,
         primitive >= 0.7.1,
-        random -any,
+        random,
         splitmix >=0.1 && <0.2,
         tasty-bench

--- a/src/System/Random/Internal.hs
+++ b/src/System/Random/Internal.hs
@@ -86,7 +86,6 @@ import Data.Int
 import Data.Word
 import Foreign.C.Types
 import Foreign.Storable (Storable)
-import GHC.ByteOrder
 import GHC.Exts
 import GHC.Generics
 import GHC.IO (IO(..))
@@ -105,6 +104,10 @@ import GHC.ForeignPtr
 #else
 import Data.ByteString (ByteString)
 #endif
+
+-- Needed for WORDS_BIGENDIAN
+#include "MachDeps.h"
+
 
 -- | 'RandomGen' is an interface to pure pseudo-random number generators.
 --
@@ -366,16 +369,19 @@ writeByteSliceWord64LE mba fromByteIx toByteIx = go fromByteIx
 {-# INLINE writeByteSliceWord64LE #-}
 
 writeWord64LE :: MBA -> Int -> Word64 -> IO ()
+#ifdef WORDS_BIGENDIAN
+writeWord64LE mba i w64 = do
+  let !i8 = i * 8
+  writeByteSliceWord64LE mba i8 (i8 + 8) w64
+#else
 writeWord64LE mba@(MBA mba#) i@(I# i#) w64@(W64# w#)
-  | targetByteOrder == BigEndian = do
-    let !i8 = i * 8
-    writeByteSliceWord64LE mba i8 (i8 + 8) w64
   | wordSizeInBits == 64 = do
     IO $ \s# -> (# writeWord64Array# mba# i# w# s#, () #)
   | otherwise = do
     let !i32 = i * 2
     writeWord32 mba i32 (fromIntegral w64)
     writeWord32 mba (i32 + 1) (fromIntegral (w64 `shiftR` 32))
+#endif
 {-# INLINE writeWord64LE #-}
 
 

--- a/src/System/Random/Internal.hs
+++ b/src/System/Random/Internal.hs
@@ -320,7 +320,6 @@ genShortByteStringIO n0 gen64 = do
   let !n@(I# n#) = max 0 n0
       !n64 = n `quot` 8
       !nrem = n `rem` 8
-      !nremStart = n - nrem
   mba@(MBA mba#) <-
     liftIO $ IO $ \s# ->
       case newByteArray# n# s# of
@@ -335,52 +334,48 @@ genShortByteStringIO n0 gen64 = do
   go 0
   when (nrem > 0) $ do
     w64 <- gen64
-    let goRem32 z i =
-          when (i < n) $ do
-            writeWord8 mba i (fromIntegral z :: Word8)
-            goRem32 (z `shiftR` 8) (i + 1)
     -- In order to not mess up the byte order we write 1 byte at a time in
     -- Little endian order. It is tempting to simply generate as many bytes as we
     -- still need using smaller generators (eg. uniformWord8), but that would
     -- result in inconsistent tail when total length is slightly varied.
-    liftIO $
-      if nrem >= 4
-      then do
-           writeWord32LE mba (nremStart `quot` 4) (fromIntegral w64)
-           goRem32 (w64 `shiftR` 32) (nremStart + 4)
-      else goRem32 w64 nremStart
+    liftIO $ writeByteSliceWord64LE mba (n - nrem) n w64
   liftIO $ IO $ \s# ->
     case unsafeFreezeByteArray# mba# s# of
       (# s'#, ba# #) -> (# s'#, SBS ba# #)
 {-# INLINE genShortByteStringIO #-}
+
+-- Architecture independent helpers:
 
 writeWord8 :: MBA -> Int -> Word8 -> IO ()
 writeWord8 (MBA mba#) (I# i#) (W8# w#) =
   IO $ \s# -> (# writeWord8Array# mba# i# w# s#, () #)
 {-# INLINE writeWord8 #-}
 
--- Architecture independent helpers:
+writeWord32 :: MBA -> Int -> Word32 -> IO ()
+writeWord32 (MBA mba#) (I# i#) (W32# w#) =
+  IO $ \s# -> (# writeWord32Array# mba# i# w# s#, () #)
+{-# INLINE writeWord32 #-}
 
-writeWord32LE :: MBA -> Int -> Word32 -> IO ()
-writeWord32LE (MBA mba#) (I# i#) w =
-  IO $ \s# -> (# writeWord32Array# mba# i# wle# s#, () #)
+writeByteSliceWord64LE :: MBA -> Int -> Int -> Word64 -> IO ()
+writeByteSliceWord64LE mba fromByteIx toByteIx = go fromByteIx
   where
-    !(W32# wle#)
-      | targetByteOrder == BigEndian = byteSwap32 w
-      | otherwise = w
-{-# INLINE writeWord32LE #-}
+    go !i !z =
+      when (i < toByteIx) $ do
+        writeWord8 mba i (fromIntegral z :: Word8)
+        go (i + 1) (z `shiftR` 8)
+{-# INLINE writeByteSliceWord64LE #-}
 
 writeWord64LE :: MBA -> Int -> Word64 -> IO ()
 writeWord64LE mba@(MBA mba#) i@(I# i#) w64@(W64# w#)
+  | targetByteOrder == BigEndian = do
+    let !i8 = i * 8
+    writeByteSliceWord64LE mba i8 (i8 + 8) w64
   | wordSizeInBits == 64 = do
-    let !wle#
-          | targetByteOrder == BigEndian = byteSwap64# w#
-          | otherwise = w#
-    IO $ \s# -> (# writeWord64Array# mba# i# wle# s#, () #)
+    IO $ \s# -> (# writeWord64Array# mba# i# w# s#, () #)
   | otherwise = do
-    let !i' = i * 2
-    writeWord32LE mba i' (fromIntegral w64)
-    writeWord32LE mba (i' + 1) (fromIntegral (w64 `shiftR` 32))
+    let !i32 = i * 2
+    writeWord32 mba i32 (fromIntegral w64)
+    writeWord32 mba (i32 + 1) (fromIntegral (w64 `shiftR` 32))
 {-# INLINE writeWord64LE #-}
 
 


### PR DESCRIPTION
This PR attempts to fix a bug that sneaked in the #116 that affects Big Endian machines

I've tested it on 32/64bit Intel and 32bit armv7 machines, however both of these are little endian and I still have not figured out a way to test big endian code. @juhp, maybe you can help us out once more and run this PR on a s390x again? Thanks to your feedback in https://github.com/haskell/random/pull/116#issuecomment-911600622 I am pretty confident that this change will do the trick.