### PR TITLE
Fix for inaccurate statement in the haddock about 32/64 bit architectures

### DIFF
--- a/src/System/Random.hs
+++ b/src/System/Random.hs
@@ -517,11 +517,12 @@ randomIO = liftIO $ getStdRandom random
 -- $reproducibility
 --
 -- If you have two builds of a particular piece of code against this library,
--- any deterministic function call should give the same result in the two
--- builds if the builds are
+-- any deterministic function call should give the same result in the two builds
+-- if the builds are compiled against the same major version of this library.
 --
--- *   compiled against the same major version of this library
--- *   on the same architecture (32-bit or 64-bit)
+-- When using the same `StdGen` with deterministic functions, they will produce
+-- the same results independently of target architecture the program was build
+-- for: 32-bit or 64-bit, big endian or little endian.
 --
 -- $references
 --


### PR DESCRIPTION
We recently where able to run the test suite on different architectures:

* 64bit s390x (Big Endian)
* 32bit Armv7,
*  and of course 32/64bit Intel x86_64/i386

A couple of new tests explicitly verify that the byte sequence produced by `StdGen` is architecture independent. These tests passed on all of those architectures. This gives me quite a bit of confidence that the statement "in order to get predictability the build has to be done on the same architecture (32-bit or 64-bit)" is not accurate. Please let me know if anyone thinks otherwise.