### PR TITLE
Fix doctests using cabal-doctest

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,4 +1,6 @@
-import Distribution.Simple
+module Main where
+
+import Distribution.Extra.Doctest (defaultMainWithDoctests)
 
 main :: IO ()
-main = defaultMain
+main = defaultMainWithDoctests "doctests"

--- a/random.cabal
+++ b/random.cabal
@@ -59,7 +59,7 @@ description:
     See "System.Random.Stateful" for more details.
 
 category:           System
-build-type:         Simple
+build-type:         Custom
 extra-source-files:
     README.md
     CHANGELOG.md
@@ -129,21 +129,21 @@ test-suite legacy-test
         random
 
 test-suite doctests
+    if impl(ghc < 8.2) || impl(ghc >= 8.10)
+        buildable: False
     type:             exitcode-stdio-1.0
     main-is:          doctests.hs
     hs-source-dirs:   test
     default-language: Haskell2010
     build-depends:
         base,
-        doctest >=0.15 && <0.20
-    if impl(ghc >= 8.2) && impl(ghc < 8.10)
-        build-depends:
-            mwc-random >=0.13 && <0.16,
-            primitive >=0.6 && <0.8,
-            random,
-            stm,
-            unliftio >=0.2 && <0.3,
-            vector >= 0.10 && <0.14
+        doctest >=0.15 && <0.20,
+        mwc-random >=0.13 && <0.16,
+        primitive >=0.6 && <0.8,
+        random,
+        stm,
+        unliftio >=0.2 && <0.3,
+        vector >= 0.10 && <0.14
 
 test-suite spec
     type:             exitcode-stdio-1.0
@@ -219,3 +219,8 @@ benchmark bench
         random,
         splitmix >=0.1 && <0.2,
         tasty-bench
+
+custom-setup
+ setup-depends:
+   base >= 4 && <5,
+   cabal-doctest >= 1 && <1.1

--- a/test/doctests.hs
+++ b/test/doctests.hs
@@ -1,18 +1,7 @@
-{-# LANGUAGE CPP #-}
 module Main where
 
-#if __GLASGOW_HASKELL__ >= 802 && __GLASGOW_HASKELL__ < 810
-
+import Build_doctests (flags, pkgs, module_sources)
 import Test.DocTest (doctest)
 
 main :: IO ()
-main = doctest ["src"]
-
-#else
-
--- Also disabled in cabal file.
--- TODO: fix doctest support
-main :: IO ()
-main = putStrLn "\nDoctests are not supported for older ghc version\n"
-
-#endif
+main = doctest $ flags ++ pkgs ++ module_sources


### PR DESCRIPTION
Tested using

    cabal test doctests --enable-tests -w ghc-8.4.4

I have changed the mechanism used to disable these test to using `buildable: False`
instead of making the test just quit. That way, the user won't be misled
into thinking that the tests were actually run.

