### PR TITLE
Update CI config, adding GHC 9.6 jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,8 +24,9 @@ jobs:
           - { os: ubuntu-latest,  ghc: "8.8.4"  }
           - { os: ubuntu-latest,  ghc: "8.10.7" }
           - { os: ubuntu-latest,  ghc: "9.0.2"  }
-          - { os: ubuntu-latest,  ghc: "9.2.4"  }
-          - { os: ubuntu-latest,  ghc: "9.4.1"  }
+          - { os: ubuntu-latest,  ghc: "9.2.7"  }
+          - { os: ubuntu-latest,  ghc: "9.4.4"  }
+          - { os: ubuntu-latest,  ghc: "9.6.1"  }
           # MacOS
           - { os: macOS-latest,  ghc: "8.0.2"  }
           - { os: macOS-latest,  ghc: "8.2.2"  }
@@ -34,8 +35,9 @@ jobs:
           - { os: macOS-latest,  ghc: "8.8.4"  }
           - { os: macOS-latest,  ghc: "8.10.7" }
           - { os: macOS-latest,  ghc: "9.0.2"  }
-          - { os: macOS-latest,  ghc: "9.2.4"  }
-          - { os: macOS-latest,  ghc: "9.4.1"  }
+          - { os: macOS-latest,  ghc: "9.2.7"  }
+          - { os: macOS-latest,  ghc: "9.4.4"  }
+          - { os: macOS-latest,  ghc: "9.6.1"  }
           # Windows
           - { os: windows-latest,  ghc: "8.0.2"  }
           - { os: windows-latest,  ghc: "8.2.2"  }
@@ -44,8 +46,9 @@ jobs:
           - { os: windows-latest,  ghc: "8.8.4"  }
           - { os: windows-latest,  ghc: "8.10.7" }
           - { os: windows-latest,  ghc: "9.0.2"  }
-          - { os: windows-latest,  ghc: "9.2.4"  }
-          - { os: windows-latest,  ghc: "9.4.1"  }
+          - { os: windows-latest,  ghc: "9.2.7"  }
+          - { os: windows-latest,  ghc: "9.4.4"  }
+          - { os: windows-latest,  ghc: "9.6.1"  }
     steps:
     - uses: actions/checkout@v3
 
@@ -58,7 +61,7 @@ jobs:
     - name: Update cabal package database
       run: cabal update
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       name: Cache cabal stuff
       with:
         path: |
@@ -81,7 +84,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        resolver: [nightly, lts-19, lts-18, lts-16, lts-14, lts-12, lts-11]
+        resolver: [nightly, lts-20, lts-19, lts-18, lts-16, lts-14, lts-12, lts-11]
         include:
           - resolver: lts-11
             ghc: 8.2.2
@@ -100,6 +103,9 @@ jobs:
           - resolver: lts-19
             ghc: 9.0.2
             stack-yaml: stack.yaml
+          - resolver: lts-20
+            ghc: 9.2.7
+            stack-yaml: stack.yaml
           - resolver: nightly
             stack-yaml: stack.yaml
           # Latest stable for MacOS: ghc-8.8.4
@@ -113,7 +119,7 @@ jobs:
     env:
       STACK_YAML: stack.yaml
       STACK_ARGS: '--resolver ${{ matrix.resolver }} --system-ghc'
-      cache-version: v4 # bump up this version to invalidate currently stored cache
+      cache-version: v5 # bump up this version to invalidate currently stored cache
     steps:
     - uses: actions/checkout@v3
 
@@ -124,11 +130,11 @@ jobs:
         ghc-version: ${{ matrix.ghc }}
         enable-stack: true
         stack-version: 'latest'
-        cabal-version: '3.6'
+        cabal-version: '3.10'
 
     - name: Cache
       id: cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.stack
@@ -148,7 +154,7 @@ jobs:
 
     - name: Windows Cache
       id: cache-windows
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       if: matrix.os == 'windows-latest'
       with:
         path: |

--- a/random.cabal
+++ b/random.cabal
@@ -132,7 +132,7 @@ test-suite doctests
     default-language: Haskell2010
     build-depends:
         base,
-        doctest >=0.15 && <0.21
+        doctest >=0.15 && <0.22
     if impl(ghc >= 8.2) && impl(ghc < 8.10)
         build-depends:
             mwc-random >=0.13 && <0.16,

--- a/test-inspection/Spec/Inspection.hs
+++ b/test-inspection/Spec/Inspection.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP              #-}
 {-# LANGUAGE DeriveAnyClass   #-}
 {-# LANGUAGE DeriveGeneric    #-}
 {-# LANGUAGE TemplateHaskell  #-}
@@ -43,7 +44,15 @@ inspectionTests = testGroup "Inspection" $
   [ $(inspectObligations [(`doesNotUse` 'StateGenM), hasNoGenerics, hasNoTypeClasses] 'uniform_Word8)
   , $(inspectObligations [(`doesNotUse` 'StateGenM), hasNoGenerics, hasNoTypeClasses] 'uniform_Int8)
   , $(inspectObligations [(`doesNotUse` 'StateGenM), hasNoGenerics, hasNoTypeClasses] 'uniform_Char)
-  , $(inspectObligations [(`doesNotUse` 'StateGenM), hasNoGenerics, hasNoTypeClasses] 'uniform_MyAction)
+  , $(inspectObligations [(`doesNotUse` 'StateGenM), hasNoTypeClasses] 'uniform_MyAction)
+
+#if !MIN_VERSION_base(4,17,0)
+  -- Starting from GHC 9.4 and base-4.17
+  -- 'error' :: M1 C ('MetaCons "Never" 'PrefixI 'False) ..
+  -- survives. This does not really matter, because Never is uninhabited,
+  -- but fails inspection testing.
+  , $(inspectTest $ hasNoGenerics 'uniform_MyAction)
+#endif
 
   , $(inspectObligations [(`doesNotUse` 'StateGenM), hasNoGenerics, hasNoTypeClasses] 'uniformR_Word8)
   , $(inspectObligations [(`doesNotUse` 'StateGenM), hasNoGenerics, hasNoTypeClasses] 'uniformR_Int8)


### PR DESCRIPTION
Inspection tests fail on GHC 9.6, because `M1` survives in types:

```haskell
        lvl_soCG
          :: M1
               C
               ('MetaCons "Never" 'PrefixI 'False)
               (S1
                  ('MetaSel
                     'Nothing 'NoSourceUnpackedness 'NoSourceStrictness 'DecidedLazy)
                  (Rec0 Void))
               Any
        lvl_soCG
          = case error (lvl_soSv `cast` <Co:4> :: ...) lvl_soSx of wild_00 {
            }

        lvl_soTe :: MyAction
        lvl_soTe = Never (lvl_soCG `cast` <Co:43> :: ...)
```

This is quite irrelevant, `data MyAction = Code (Maybe Bool) | Never Void | Eat (Bool, Bool) | Sleep ()` and we do not really care about optimization of `error :: Void`, but I'm unsure what's the best way to mute this test. 