### PR TITLE
Add big-endian CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -244,3 +244,28 @@ jobs:
         name: Run build (arm64v8 linux)
         with:
           args: sh -c "cabal update && cabal test"
+
+  # Emulation on s390x platform is incredibly slow and memory demanding.
+  # It seems that any executable with GHC RTS takes at least 7-8 Gb of RAM, so we can
+  # run `cabal` or `ghc` on their own, but cannot run them both at the same time, striking
+  # out `cabal test`. Instead we rely on system packages and invoke `ghc --make` manually,
+  # and even so `ghc -O` is prohibitively expensive.
+  s390x:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: uraimo/run-on-arch-action@v2.5.0
+      timeout-minutes: 60
+      with:
+        arch: s390x
+        distro: ubuntu_rolling
+        githubToken: ${{ github.token }}
+        install: |
+          apt-get update -y
+          apt-get install -y ghc libghc-tasty-smallcheck-dev libghc-tasty-hunit-dev libghc-splitmix-dev curl
+        run: |
+          ghc --version
+          ghc --make -isrc:test-legacy -o legacy test-legacy/Legacy.hs
+          ./legacy
+          ghc --make -isrc:test -o spec test/Spec.hs
+          ./spec


### PR DESCRIPTION
Following up on #116 and #118 saga, let's add a big-endian CI job, similarly to what `bytestring` and `text` do.