### PR TITLE
Export helper functions `isInRangeOrd` and `isInRangeEnum`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
   * Add `splitGen` and `splitMutableGen`
   * Switch `randomM` and `randomRM` to use `FrozenGen` instead of `RandomGenM`
   * Deprecate `RandomGenM` in favor of a more powerful `FrozenGen`
+* Add `isInRangeOrd` and `isInRangeEnum` that can be used for implementing `isInRange`:
+  [#148](https://github.com/haskell/random/pull/148)
 * Add `isInRange` to `UniformRange`: [#78](https://github.com/haskell/random/pull/78)
 * Add default implementation for `uniformRM` using `Generics`:
   [#92](https://github.com/haskell/random/pull/92)

--- a/src/System/Random/Internal.hs
+++ b/src/System/Random/Internal.hs
@@ -62,6 +62,8 @@ module System.Random.Internal
   , uniformEnumRM
   , uniformListM
   , uniformListRM
+  , isInRangeOrd
+  , isInRangeEnum
 
   -- * Generators for sequences of pseudo-random bytes
   , uniformByteStringM
@@ -1032,7 +1034,9 @@ class UniformRange a where
   -- > isInRange (lo, hi) lo' && isInRange (lo, hi) hi' && isInRange (lo', hi') x
   -- > ==> isInRange (lo, hi) x
   --
-  -- There is a default implementation of 'isInRange' via 'Generic'.
+  -- There is a default implementation of 'isInRange' via 'Generic'. Other helper function
+  -- that can be used for implementing this function are `isInRangeOrd` and
+  -- `isInRangeEnum`
   --
   -- @since 1.3.0
   isInRange :: (a, a) -> a -> Bool
@@ -1071,8 +1075,19 @@ instance (GUniformRange f, GUniformRange g) => GUniformRange (f :*: g) where
   gisInRange (x1 :*: y1, x2 :*: y2) (x3 :*: y3) =
     gisInRange (x1, x2) x3 && gisInRange (y1, y2) y3
 
+-- | Utilize `Ord` instance to decide if a value is within the range. Designed to be used
+-- for implementing `isInRange`
+--
+-- @since 1.3.0
 isInRangeOrd :: Ord a => (a, a) -> a -> Bool
 isInRangeOrd (a, b) x = min a b <= x && x <= max a b
+
+-- | Utilize `Enum` instance to decide if a value is within the range. Designed to be used
+-- for implementing `isInRange`
+--
+-- @since 1.3.0
+isInRangeEnum :: Enum a => (a, a) -> a -> Bool
+isInRangeEnum (a, b) x = isInRangeOrd (fromEnum a, fromEnum b) (fromEnum x)
 
 instance UniformRange Integer where
   uniformRM = uniformIntegralM

--- a/src/System/Random/Stateful.hs
+++ b/src/System/Random/Stateful.hs
@@ -92,6 +92,8 @@ module System.Random.Stateful
   , Uniform(..)
   , uniformViaFiniteM
   , UniformRange(..)
+  , isInRangeOrd
+  , isInRangeEnum
 
   -- ** Lists
   , uniformListM


### PR DESCRIPTION
For those types that do not rely on Generics and define the `UniformRange` instance manually these two functions can be very helpful.