### PR TITLE
Deprecate `RandomGenM` in favor of a more powerful `FrozenGen`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 1.3.0
 
+* Move `thawGen` from `FreezeGen` into the new `ThawGen` type class. Fixes an issue with
+  an unlawful instance of `StateGen` for `FreezeGen`.
 * Add `modifyGen` and `overwriteGen` to the `FrozenGen` type class
 * Add `splitGen` and `splitMutableGen`
 * Switch `randomM` and `randomRM` to use `FrozenGen` instead of `RandomGenM`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 1.3.0
 
+* Add `modifyGen` to the `FrozenGen` type class
+* Add `splitGen` and `splitMutableGen`
+* Switch `randomM` and `randomRM` to use `FrozenGen` instead of `RandomGenM`
+* Deprecate `RandomGenM` in favor of a more powerful `FrozenGen`
 * Add `isInRange` to `UniformRange`: [#78](https://github.com/haskell/random/pull/78)
 * Add default implementation for `uniformRM` using `Generics`:
   [#92](https://github.com/haskell/random/pull/92)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.3.0
 
-* Add `modifyGen` to the `FrozenGen` type class
+* Add `modifyGen` and `overwriteGen` to the `FrozenGen` type class
 * Add `splitGen` and `splitMutableGen`
 * Switch `randomM` and `randomRM` to use `FrozenGen` instead of `RandomGenM`
 * Deprecate `RandomGenM` in favor of a more powerful `FrozenGen`

--- a/src/System/Random/Internal.hs
+++ b/src/System/Random/Internal.hs
@@ -309,11 +309,17 @@ class StatefulGen (MutableGen f m) m => FrozenGen f m where
   -- @since 1.2.0
   thawGen :: f -> m (MutableGen f m)
 
-  -- | Apply a pure function to the frozen generator.
+  -- | Apply a pure function to the frozen pseudo-random number generator.
   --
   -- @since 1.3.0
   modifyGen :: MutableGen f m -> (f -> (a, f)) -> m a
 
+  -- | Overwrite contents of the mutable pseudo-random number generator with the
+  -- supplied frozen one
+  --
+  -- @since 1.3.0
+  overwriteGen :: MutableGen f m -> f -> m ()
+  overwriteGen mg fg = modifyGen mg (const ((), fg))
 
 -- | Splits a pseudo-random number generator into two. Overwrites the mutable
 -- wrapper with one of the resulting generators and returns the other.
@@ -478,6 +484,8 @@ instance (RandomGen g, MonadState g m) => FrozenGen (StateGen g) m where
   thawGen (StateGen g) = StateGenM <$ put g
   modifyGen _ f = state (coerce f)
   {-# INLINE modifyGen #-}
+  overwriteGen _ f = put (coerce f)
+  {-# INLINE overwriteGen #-}
 
 -- | Runs a monadic generating action in the `State` monad using a pure
 -- pseudo-random number generator.

--- a/src/System/Random/Stateful.hs
+++ b/src/System/Random/Stateful.hs
@@ -164,9 +164,10 @@ import System.Random.Internal
 -- > [3,4,3,1,4,6,1,6,1,4]
 --
 -- Given a /pure/ pseudo-random number generator, you can run the monadic pseudo-random
--- number computation @rollsM@ in 'StateT', 'IO', 'ST' or 'STM' context by applying a
--- monadic adapter like 'StateGenM', 'AtomicGenM', 'IOGenM', 'STGenM' or 'TGenM' (see
--- [monadic-adapters](#monadicadapters)) to the pure pseudo-random number generator.
+-- number computation @rollsM@ in 'Control.Monad.State.Strict.StateT', 'IO', 'ST' or 'STM'
+-- context by applying a monadic adapter like 'StateGenM', 'AtomicGenM', 'IOGenM',
+-- 'STGenM' or 'TGenM' (see [monadic-adapters](#monadicadapters)) to the pure
+-- pseudo-random number generator.
 --
 -- >>> let pureGen = mkStdGen 42
 -- >>> newIOGenM pureGen >>= rollsM 10 :: IO [Word]
@@ -183,9 +184,9 @@ import System.Random.Internal
 -- ['System.Random.RandomGen': pure pseudo-random number generators]
 --     See "System.Random" module.
 --
--- ['StatefulGen': monadic pseudo-random number generators] These generators
---     mutate their own state as they produce pseudo-random values. They
---     generally live in 'StateT', 'ST', 'IO' or 'STM' or some other transformer
+-- ['StatefulGen': monadic pseudo-random number generators] These generators mutate their
+--     own state as they produce pseudo-random values. They generally live in
+--     'Control.Monad.State.Strict.StateT', 'ST', 'IO' or 'STM' or some other transformer
 --     on top of those monads.
 --
 
@@ -198,10 +199,10 @@ import System.Random.Internal
 -- Pure pseudo-random number generators can be used in monadic code via the
 -- adapters 'StateGenM', 'AtomicGenM', 'IOGenM', 'STGenM' and 'TGenM'
 --
--- *   'StateGenM' can be used in any state monad. With strict 'StateT' there is
---     no performance overhead compared to using the 'RandomGen' instance
---     directly. 'StateGenM' is /not/ safe to use in the presence of exceptions
---     and concurrency.
+-- * 'StateGenM' can be used in any state monad. With strict
+--     'Control.Monad.State.Strict.StateT' there is no performance overhead compared to
+--     using the 'RandomGen' instance directly. 'StateGenM' is /not/ safe to use in the
+--     presence of exceptions and concurrency.
 --
 -- *   'AtomicGenM' is safe in the presence of exceptions and concurrency since
 --     it performs all actions atomically.

--- a/src/System/Random/Stateful.hs
+++ b/src/System/Random/Stateful.hs
@@ -473,6 +473,8 @@ instance (RandomGen g, MonadIO m) => FrozenGen (IOGen g) m where
     g' `seq` writeIORef ref g'
     pure a
   {-# INLINE modifyGen #-}
+  overwriteGen (IOGenM ref) = liftIO . writeIORef ref . unIOGen
+  {-# INLINE overwriteGen #-}
 
 -- | Applies a pure operation to the wrapped pseudo-random number generator.
 --
@@ -538,6 +540,8 @@ instance RandomGen g => FrozenGen (STGen g) (ST s) where
     g' `seq` writeSTRef ref g'
     pure a
   {-# INLINE modifyGen #-}
+  overwriteGen (STGenM ref) = writeSTRef ref . unSTGen
+  {-# INLINE overwriteGen #-}
 
 
 -- | Applies a pure operation to the wrapped pseudo-random number generator.
@@ -639,6 +643,8 @@ instance RandomGen g => FrozenGen (TGen g) STM where
     g' `seq` writeTVar ref g'
     pure a
   {-# INLINE modifyGen #-}
+  overwriteGen (TGenM ref) = writeTVar ref . unTGen
+  {-# INLINE overwriteGen #-}
 
 
 -- | Applies a pure operation to the wrapped pseudo-random number generator.

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -94,7 +94,7 @@ main =
     , uniformSpec (Proxy :: Proxy (Word8, Word16, Word32, Word64, Word))
     , uniformSpec (Proxy :: Proxy (Int8, Word8, Word16, Word32, Word64, Word))
     , uniformSpec (Proxy :: Proxy (Int8, Int16, Word8, Word16, Word32, Word64, Word))
-    , Stateful.statefulSpec
+    , Stateful.statefulGenSpec
     ]
 
 floatTests :: TestTree


### PR DESCRIPTION
* Addition of `modifyGen` totally removes the need for `RandomGenM`, because every frozen generator that is a `netwtype` wrapper around `RandomGen` also derives an instance for `RandomGen`
* Add `splitMutableGen` and `splitGen`
* Add `ThawedGen` and move `thawGen` into that type class to combat current unlawful `FrozenGen` instance for `StateGen`
