### PR TITLE
Remove dependency on mwc-random in doctests

### DIFF
--- a/random.cabal
+++ b/random.cabal
@@ -131,7 +131,6 @@ test-suite doctests
         doctest >=0.15 && <0.23
     if impl(ghc >= 8.2) && impl(ghc < 8.10)
         build-depends:
-            mwc-random >=0.13 && <0.16,
             primitive >=0.6 && <0.8,
             random,
             stm,


### PR DESCRIPTION
We need to remove dependency on `mwc-random`, because starting with version 0.15 it depends on `random`, which creates a circular dependency.