### PR TITLE
Introduce new `SplitGen` type class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.3.0
 
+* Add `SplitGen` and `splitGen`
 * Add `shuffleList` and `shuffleListM`: [#140](https://github.com/haskell/random/pull/140)
 * Add `mkStdGen64`: [#155](https://github.com/haskell/random/pull/155)
 * Add `uniformListRM`, `uniformList`, `uniformListR`, `uniforms` and `uniformRs`:
@@ -23,7 +24,8 @@
   * Move `thawGen` from `FreezeGen` into the new `ThawGen` type class. Fixes an issue with
     an unlawful instance of `StateGen` for `FreezeGen`.
   * Add `modifyGen` and `overwriteGen` to the `FrozenGen` type class
-  * Add `splitGen` and `splitMutableGen`
+  * Switch `splitGenM` to use `SplitGen` and `FrozenGen` instead of deprecated `RandomGenM`
+  * Add `splitMutableGenM`
   * Switch `randomM` and `randomRM` to use `FrozenGen` instead of `RandomGenM`
   * Deprecate `RandomGenM` in favor of a more powerful `FrozenGen`
 * Add `isInRangeOrd` and `isInRangeEnum` that can be used for implementing `isInRange`:

--- a/src/System/Random.hs
+++ b/src/System/Random.hs
@@ -30,6 +30,7 @@ module System.Random
       , genWord64R
       , unsafeUniformFillMutableByteArray
       )
+  , SplitGen (splitGen)
   , uniform
   , uniformR
   , Random(..)
@@ -632,7 +633,7 @@ getStdGen = liftIO $ readIORef theStdGen
 --
 -- @since 1.0.0
 newStdGen :: MonadIO m => m StdGen
-newStdGen = liftIO $ atomicModifyIORef' theStdGen split
+newStdGen = liftIO $ atomicModifyIORef' theStdGen splitGen
 
 -- | Uses the supplied function to get a value from the current global
 -- random generator, and updates the global generator with the new generator

--- a/src/System/Random/Stateful.hs
+++ b/src/System/Random/Stateful.hs
@@ -43,12 +43,11 @@ module System.Random.Stateful
   , withMutableGen_
   , randomM
   , randomRM
-  , splitGen
-  , splitMutableGen
+  , splitGenM
+  , splitMutableGenM
 
   -- ** Deprecated
   , RandomGenM(..)
-  , splitGenM
 
   -- * Monadic adapters for pure pseudo-random number generators #monadicadapters#
   -- $monadicadapters
@@ -249,14 +248,6 @@ class (RandomGen r, StatefulGen g m) => RandomGenM g r m | g -> r where
 {-# DEPRECATED applyRandomGenM "In favor of `modifyGen`" #-}
 {-# DEPRECATED RandomGenM "In favor of `FrozenGen`" #-}
 
--- | Splits a pseudo-random number generator into two. Overwrites the mutable
--- wrapper with one of the resulting generators and returns the other.
---
--- @since 1.2.0
-splitGenM :: RandomGenM g r m => g -> m r
-splitGenM = applyRandomGenM split
-{-# DEPRECATED splitGenM "In favor of `splitGen`" #-}
-
 instance (RandomGen r, MonadIO m) => RandomGenM (IOGenM r) r m where
   applyRandomGenM = applyIOGen
 
@@ -360,7 +351,7 @@ newtype AtomicGenM g = AtomicGenM { unAtomicGenM :: IORef g}
 --
 -- @since 1.2.0
 newtype AtomicGen g = AtomicGen { unAtomicGen :: g}
-  deriving (Eq, Ord, Show, RandomGen, Storable, NFData)
+  deriving (Eq, Ord, Show, RandomGen, SplitGen, Storable, NFData)
 
 -- | Creates a new 'AtomicGenM'.
 --
@@ -451,7 +442,7 @@ newtype IOGenM g = IOGenM { unIOGenM :: IORef g }
 --
 -- @since 1.2.0
 newtype IOGen g = IOGen { unIOGen :: g }
-  deriving (Eq, Ord, Show, RandomGen, Storable, NFData)
+  deriving (Eq, Ord, Show, RandomGen, SplitGen, Storable, NFData)
 
 
 -- | Creates a new 'IOGenM'.
@@ -522,7 +513,7 @@ newtype STGenM g s = STGenM { unSTGenM :: STRef s g }
 --
 -- @since 1.2.0
 newtype STGen g = STGen { unSTGen :: g }
-  deriving (Eq, Ord, Show, RandomGen, Storable, NFData)
+  deriving (Eq, Ord, Show, RandomGen, SplitGen, Storable, NFData)
 
 -- | Creates a new 'STGenM'.
 --
@@ -617,7 +608,7 @@ newtype TGenM g = TGenM { unTGenM :: TVar g }
 --
 -- @since 1.2.1
 newtype TGen g = TGen { unTGen :: g }
-  deriving (Eq, Ord, Show, RandomGen, Storable, NFData)
+  deriving (Eq, Ord, Show, RandomGen, SplitGen, Storable, NFData)
 
 -- | Creates a new 'TGenM' in `STM`.
 --

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -299,7 +299,8 @@ newtype ConstGen = ConstGen Word64
 
 instance RandomGen ConstGen where
   genWord64 g@(ConstGen c) = (c, g)
-  split g = (g, g)
+instance SplitGen ConstGen where
+  splitGen g = (g, g)
 
 data Colors = Red | Green | Blue | Purple | Yellow | Black | White | Orange
   deriving (Eq, Ord, Show, Generic, Enum, Bounded)

--- a/test/Spec/Stateful.hs
+++ b/test/Spec/Stateful.hs
@@ -101,19 +101,19 @@ immutableFrozenGenSpec toIO frozen =
     pure $ all (x ==) xs
 
 splitMutableGenSpec ::
-     forall f m. (RandomGen f, ThawedGen f m, Eq f, Show f)
+     forall f m. (SplitGen f, ThawedGen f m, Eq f, Show f)
   => (forall a. m a -> IO a)
   -> f
   -> Property IO
 splitMutableGenSpec toIO frozen =
   monadic $ toIO $ do
-    (sfg1, fg1) <- withMutableGen frozen splitGen
-    (smg2, fg2) <- withMutableGen frozen splitMutableGen
+    (sfg1, fg1) <- withMutableGen frozen splitGenM
+    (smg2, fg2) <- withMutableGen frozen splitMutableGenM
     sfg3 <- freezeGen smg2
     pure $ fg1 == fg2 && sfg1 == sfg3
 
 thawedGenSpecFor ::
-     forall f m. (RandomGen f, ThawedGen f m, Eq f, Show f, Serial IO f, Typeable f)
+     forall f m. (SplitGen f, ThawedGen f m, Eq f, Show f, Serial IO f, Typeable f)
   => (forall a. m a -> IO a)
   -> Proxy f
   -> TestTree


### PR DESCRIPTION
Fixes #97 

I've been thinking for a while about this and I think the correct path forward is to introduce a separate class for splittable generators, which I called `SplitGen` and deprecate the old `split` function.

The benefit of this approach is that current user code does not break and gives a graceful path to upgrade to the new type class.

Other approaches were considered in #94 and discussed at length in https://github.com/idontgetoutmuch/random/issues/7

I highly doubt that we will provide a generic approach of using some hash function for implementing PRNG splitting. I would rather prefer such functionality be in a separate library that other packages that want to implement `SplitGen` can opt-in into using.