### PR TITLE
To `newtype StateGen` add deriving `SplitGen`.

### DIFF
--- a/src/System/Random/Internal.hs
+++ b/src/System/Random/Internal.hs
@@ -610,7 +610,7 @@ data StateGenM g = StateGenM
 --
 -- @since 1.2.0
 newtype StateGen g = StateGen { unStateGen :: g }
-  deriving (Eq, Ord, Show, RandomGen, Storable, NFData)
+  deriving (Eq, Ord, Show, RandomGen, SplitGen, Storable, NFData)
 
 instance (RandomGen g, MonadState g m) => StatefulGen (StateGenM g) m where
   uniformWord32R r _ = state (genWord32R r)


### PR DESCRIPTION
`newtype StateGen` now derives `SplitGen`.

Fixes #182